### PR TITLE
Use Unix domain socket for PostgreSQL connections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ commands:
       - start-service:
           description: PostgreSQL
           service: postgres
+      - run: sleep 5
       - run: ./ci/compose.sh create createdb
       - run: ./ci/compose.sh run createdb
       - start-service:
@@ -564,6 +565,7 @@ jobs:
       - start-service:
           description: PostgreSQL
           service: postgres
+      - run: sleep 5
       - run: ./ci/compose.sh create createdb
       - run: ./ci/compose.sh run createdb
       - run: ./ci/worker_health_fail.sh

--- a/config/circleci.json
+++ b/config/circleci.json
@@ -1,9 +1,4 @@
 {
-  "db": {
-    "query": {
-      "unix_sock": "/var/run/postgresql/.s.PGSQL.5432"
-    }
-  },
   "extends": "test.json",
   "model": {
     "random_padding_suggestions": 0

--- a/config/circleci.json
+++ b/config/circleci.json
@@ -1,4 +1,9 @@
 {
+  "db": {
+    "query": {
+      "unix_sock": "/var/run/postgresql/.s.PGSQL.5432"
+    }
+  },
   "extends": "test.json",
   "model": {
     "random_padding_suggestions": 0

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -8,6 +8,7 @@
     "query": {
       "unix_sock": "/var/run/postgresql/.s.PGSQL.5432"
     },
+    "ssl": false,
     "user": "produser"
   },
   "queue": {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -4,7 +4,11 @@
     "app_url": "https://sigopt.ninja:4443"
   },
   "db": {
-    "path": "basedb"
+    "path": "basedb",
+    "query": {
+      "unix_sock": "/var/run/postgresql/.s.PGSQL.5432"
+    },
+    "user": "produser"
   },
   "queue": {
     "message_groups": {

--- a/config/sigopt.yml
+++ b/config/sigopt.yml
@@ -12,6 +12,8 @@ db:
   host: postgres
   password: produser_password_for_development
   path: basedb
+  query:
+    unix_sock: /var/run/postgresql/.s.PGSQL.5432
   ssl: false
   user: produser
 extends: defaults.json

--- a/config/sigopt.yml
+++ b/config/sigopt.yml
@@ -10,8 +10,6 @@ clients:
   enabled: true
 db:
   host: postgres
-  password: produser_password_for_development
-  path: basedb
   query:
     unix_sock: /var/run/postgresql/.s.PGSQL.5432
   ssl: false

--- a/config/sigopt.yml
+++ b/config/sigopt.yml
@@ -8,12 +8,6 @@ clients:
       name: Default Owner
       password: owner
   enabled: true
-db:
-  host: postgres
-  query:
-    unix_sock: /var/run/postgresql/.s.PGSQL.5432
-  ssl: false
-  user: produser
 extends: defaults.json
 redis:
   host: redis

--- a/config/test.json
+++ b/config/test.json
@@ -18,12 +18,7 @@
     ]
   },
   "db": {
-    "host": "postgres",
-    "password": "produser_password_for_development",
-    "path": "basedb",
-    "scheme": "postgresql+pg8000",
-    "ssl": false,
-    "user": "produser"
+    "password": "produser_password_for_development"
   },
   "email": {
     "enabled": true,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,6 +46,7 @@ services:
       - *api-tls-verify-env
     image: sigopt/test-runner-web:latest
     volumes:
+      - &pg-sock-volume pg-sock:/var/run/postgresql
       - /dev/shm:/dev/shm
       - &babelrc ./.babelrc:/sigopt-server/.babelrc:ro
       - *rootca-volume
@@ -62,7 +63,6 @@ services:
       - ./test:/sigopt-server/test:delegated
       - ./web:/sigopt-server/web:ro,cached
       - ./webpack.config.script.babel.js:/sigopt-server/webpack.config.script.babel.js
-      - /var/run/docker.sock:/var/run/docker.sock
       - &test-routes-volume test-routes:/sigopt-server/artifacts/web/routes
     working_dir: /sigopt-server
     depends_on:
@@ -108,6 +108,7 @@ services:
     stdin_open: true
     tty: true
     volumes:
+      - *pg-sock-volume
       - ./config:/sigopt-server/config:ro
       - ./sigoptcompute/sigoptcompute:/sigopt-server/sigoptcompute/sigoptcompute:ro
       - ./sigoptaux/sigoptaux:/sigopt-server/sigoptaux/sigoptaux:ro
@@ -159,6 +160,7 @@ services:
     stdin_open: true
     tty: true
     volumes: &zigopt_volumes
+      - *pg-sock-volume
       - ./config:/sigopt-server/config:ro
       - ./sigoptcompute/sigoptcompute:/sigopt-server/sigoptcompute/sigoptcompute:ro
       - ./sigoptaux/sigoptaux:/sigopt-server/sigoptaux/sigoptaux:ro
@@ -237,6 +239,7 @@ services:
     stdin_open: true
     tty: true
     volumes:
+      - *pg-sock-volume
       - "./artifacts/tls:/etc/ssl/sigopt:ro"
       - "./config:/sigopt-server/config:ro"
       - "./sigoptcompute/sigoptcompute:/sigopt-server/sigoptcompute/sigoptcompute:ro"
@@ -384,6 +387,7 @@ services:
     stdin_open: true
     tty: true
     volumes:
+      - *pg-sock-volume
       - ./artifacts/tls:/etc/ssl/sigopt:ro
       - .pyrepl.py:/sigopt-server/.pyrepl.py:ro
       - ./config:/sigopt-server/config:ro
@@ -535,8 +539,8 @@ services:
       <<: *logging
     image: "postgres:${POSTGRES_VERSION}"
     volumes:
-      - pgvolume:/var/lib/postgresql/data
-      - pg-var:/var/run/postgresql
+      - *pg-sock-volume
+      - pg-data:/var/lib/postgresql/data
     tmpfs:
       - /tmp
     read_only: true
@@ -667,8 +671,8 @@ services:
 volumes:
   minio-config: {}
   minio-data: {}
-  pg-var: {}
-  pgvolume: {}
+  pg-data: {}
+  pg-sock: {}
   server-bin: {}
   static-artifacts: {}
   test-routes: {}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -543,10 +543,8 @@ services:
       - pg-data:/var/lib/postgresql/data
     tmpfs:
       - /tmp
+    network_mode: none
     read_only: true
-    ports:
-      - target: 5432
-        host_ip: 127.0.0.1
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,7 +222,6 @@ services:
     volumes:
       - *pg-sock-volume
       - pg-data:/var/lib/postgresql/data
-      - pg-var:/var/run/postgresql
     tmpfs:
       - /tmp
     network_mode: none
@@ -338,4 +337,3 @@ volumes:
   minio-data: {}
   pg-data: {}
   pg-sock: {}
-  pg-var: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ./screenshots/failure:/sigopt-server/screenshots/failure
       - ./failure_console_logs:/sigopt-server/failure_console_logs
       - /dev/shm:/dev/shm
+      - &pg-sock-volume pg-sock:/var/run/postgresql
   smtp:
     restart: on-failure:5
     command:
@@ -56,6 +57,7 @@ services:
       - "no-new-privileges:true"
     volumes:
       - *sigopt-config-volume
+      - *pg-sock-volume
   nginx:
     restart: on-failure:5
     image: "sigopt/nginx:${TAG}"
@@ -99,6 +101,7 @@ services:
       - "sigopt_server_version=git:$TAG"
     volumes:
       - *sigopt-config-volume
+      - *pg-sock-volume
     tmpfs:
       - /tmp
     networks:
@@ -167,6 +170,7 @@ services:
     environment: *zigopt_environment
     volumes:
       - *sigopt-config-volume
+      - *pg-sock-volume
     deploy:
       resources:
         limits:
@@ -199,6 +203,7 @@ services:
     environment: *zigopt_environment
     volumes:
       - *sigopt-config-volume
+      - *pg-sock-volume
     deploy:
       resources:
         limits:
@@ -215,14 +220,13 @@ services:
     restart: on-failure:5
     image: "postgres:${POSTGRES_VERSION}"
     volumes:
+      - *pg-sock-volume
       - pg-data:/var/lib/postgresql/data
       - pg-var:/var/run/postgresql
     tmpfs:
       - /tmp
+    network_mode: none
     read_only: true
-    ports:
-      - target: 5432
-        host_ip: 127.0.0.1
     deploy:
       resources:
         limits:
@@ -332,5 +336,6 @@ services:
 
 volumes:
   minio-data: {}
-  pg-var: {}
   pg-data: {}
+  pg-sock: {}
+  pg-var: {}

--- a/src/python/zigopt/db/service.py
+++ b/src/python/zigopt/db/service.py
@@ -131,6 +131,7 @@ class DatabaseConnectionService(Service):
         host=config.get("host"),
         port=config.get("port"),
         database=config.get("path"),
+        query=config.get("query"),
       ),
       connect_args=connect_args,
       execution_options={

--- a/src/python/zigopt/db/service.py
+++ b/src/python/zigopt/db/service.py
@@ -131,7 +131,7 @@ class DatabaseConnectionService(Service):
         host=config.get("host"),
         port=config.get("port"),
         database=config.get("path"),
-        query=config.get("query"),
+        query=config.get_object("query"),
       ),
       connect_args=connect_args,
       execution_options={

--- a/src/python/zigopt/db/service.py
+++ b/src/python/zigopt/db/service.py
@@ -131,7 +131,7 @@ class DatabaseConnectionService(Service):
         host=config.get("host"),
         port=config.get("port"),
         database=config.get("path"),
-        query=config.get_object("query"),
+        query=config.get("query"),
       ),
       connect_args=connect_args,
       execution_options={

--- a/src/python/zigopt/utils/create_database.py
+++ b/src/python/zigopt/utils/create_database.py
@@ -98,6 +98,7 @@ def setup_db(config_broker, allow_list=True, superuser=None, superuser_password=
         "password": superuser_password,
         "host": config_broker.get("db.host"),
         "port": config_broker.get("db.port"),
+        **(config_broker.get("db.query") or {}),
       }
     )
   )

--- a/src/python/zigopt/utils/create_database.py
+++ b/src/python/zigopt/utils/create_database.py
@@ -257,12 +257,14 @@ def create_db(
   database = config_broker.get("db.path")
   username = config_broker.get("db.user")
   password = config_broker.get("db.password")
+  query = config_broker.get_object("db.query")
   if allow_list:
     assert username in USERNAME_ALLOW_LIST
   make_produser(
     host=host,
     port=port,
     database=database,
+    query=query,
     produser=username,
     produser_password=password,
     superuser=superuser,

--- a/src/python/zigopt/utils/create_database.py
+++ b/src/python/zigopt/utils/create_database.py
@@ -98,7 +98,7 @@ def setup_db(config_broker, allow_list=True, superuser=None, superuser_password=
         "password": superuser_password,
         "host": config_broker.get("db.host"),
         "port": config_broker.get("db.port"),
-        **(config_broker.get("db.query") or {}),
+        **(config_broker.get_object("db.query") or {}),
       }
     )
   )

--- a/src/python/zigopt/utils/create_produser.py
+++ b/src/python/zigopt/utils/create_produser.py
@@ -15,7 +15,7 @@ DELETE_ALLOW_LIST = ["tokens", "invites", "roles", "experiment_optimization_aux"
 
 
 @contextmanager
-def make_db_connection(host, port, database, user, password):
+def make_db_connection(host, port, database, query, user, password):
   conn = pg8000.connect(
     **remove_nones(
       {
@@ -24,6 +24,7 @@ def make_db_connection(host, port, database, user, password):
         "database": database,
         "user": user or "postgres",
         "password": password,
+        **(query or {}),
       }
     )
   )
@@ -34,11 +35,11 @@ def make_db_connection(host, port, database, user, password):
     conn.close()
 
 
-def make_produser(host, port, database, produser, produser_password, superuser=None, superuser_password=None):
+def make_produser(host, port, database, query, produser, produser_password, superuser=None, superuser_password=None):
   if not produser.isalnum():
     raise Exception(f"Invalid username: {produser}")
 
-  with make_db_connection(host, port, database, user=superuser, password=superuser_password) as conn:
+  with make_db_connection(host, port, database, query=query, user=superuser, password=superuser_password) as conn:
     with conn.cursor() as cursor:
       execute_create_user_query(
         conn=conn,

--- a/src/python/zigopt/utils/create_produser.py
+++ b/src/python/zigopt/utils/create_produser.py
@@ -62,11 +62,15 @@ def make_produser(host, port, database, produser, produser_password, superuser=N
 
 
 def execute_create_user_query(conn, cursor, user, password, roles=""):
-  psql_password = password.replace("'", "''")
+  if password is None:
+    query_string = f"CREATE ROLE {user} {roles}"
+  else:
+    psql_password = password.replace("'", "''")
+    query_string = f"CREATE ROLE {user} WITH LOGIN PASSWORD '{psql_password}' {roles}"
   return execute_query(
     conn=conn,
     cursor=cursor,
-    query_string=f"CREATE ROLE {user} WITH LOGIN PASSWORD '{psql_password}' {roles}",
+    query_string=query_string,
     error_allow_list=[
       dict(error_str="already exists", warning=f'role: "{user}" already exists. Existing role will be used.')
     ],

--- a/src/python/zigopt/utils/create_produser.py
+++ b/src/python/zigopt/utils/create_produser.py
@@ -64,7 +64,7 @@ def make_produser(host, port, database, query, produser, produser_password, supe
 
 def execute_create_user_query(conn, cursor, user, password, roles=""):
   if password is None:
-    query_string = f"CREATE ROLE {user} {roles}"
+    query_string = f"CREATE ROLE {user} WITH LOGIN {roles}"
   else:
     psql_password = password.replace("'", "''")
     query_string = f"CREATE ROLE {user} WITH LOGIN PASSWORD '{psql_password}' {roles}"


### PR DESCRIPTION
Use only Unix domain sockets for database connections so we don't need to maintain passwords for PostgreSQL users. Networking for the PostgreSQL container is disabled.