### PR TITLE
More precise errors

### DIFF
--- a/src/python/zigopt/api/request.py
+++ b/src/python/zigopt/api/request.py
@@ -20,7 +20,7 @@ from libsigopt.aux.errors import InvalidKeyError, InvalidValueError, MissingPara
 DEFAULT_PAGING_MAX_LIMIT = 1000
 
 
-def validate_api_input_string(input_string):
+def validate_api_input_string(input_string: str) -> str:
   assert isinstance(input_string, str)
   # Postgres treats any string with a NUL-byte (the Unicode code point 0, represented as '\0' in UTF-8)
   # as invalid, even though it is valid UTF-8 string.

--- a/src/python/zigopt/api/request.py
+++ b/src/python/zigopt/api/request.py
@@ -11,24 +11,24 @@ from flask import Request as RequestBase
 from zigopt.common import *
 from zigopt.api.paging import deserialize_paging_marker
 from zigopt.handlers.validate.validate_dict import ValidationType, validate_type
-from zigopt.net.errors import BadParamError, RequestError
+from zigopt.net.errors import RequestError
 from zigopt.pagination.paging import PagingRequest, SortRequest
 
-from libsigopt.aux.errors import MissingParamError
+from libsigopt.aux.errors import InvalidKeyError, InvalidValueError, MissingParamError, SigoptValidationError
 
 
 DEFAULT_PAGING_MAX_LIMIT = 1000
 
 
-def validate_api_input_string(input_str: str) -> str:
-  assert isinstance(input_str, str)
+def validate_api_input_string(input_string):
+  assert isinstance(input_string, str)
   # Postgres treats any string with a NUL-byte (the Unicode code point 0, represented as '\0' in UTF-8)
   # as invalid, even though it is valid UTF-8 string.
   # We are natively rejecting all other invalid UTF-8 so we just need to reject strings with NUL bytes
   # as a special case.
-  if "\0" in input_str:
-    raise BadParamError(f"Invalid string parameter: {input_str}")
-  return input_str
+  if "\0" in input_string:
+    raise SigoptValidationError(f"Invalid string parameter: {input_string}")
+  return input_string
 
 
 def validate_api_input(val):
@@ -55,12 +55,12 @@ def object_pairs_hook_raise_on_duplicates(ordered_pairs):
     key = validate_api_input(key)
     value = validate_api_input(value)
     if key in output_dict:
-      raise BadParamError(f"Duplicate key value in JSON document: {key}")
+      raise InvalidKeyError(key, f"Duplicate key value in JSON document: {key}")
     output_dict[key] = value
   return output_dict
 
 
-class InvalidJsonValue(BadParamError):
+class InvalidJsonValue(SigoptValidationError):
   pass
 
 
@@ -96,9 +96,9 @@ def as_json(data: bytes, encoding: str = "utf-8"):
       parse_float=parse_float,
     )
   except json.JSONDecodeError as e:
-    raise BadParamError("Invalid json: " + data.decode(encoding)) from e
+    raise SigoptValidationError("Invalid json: " + data.decode(encoding)) from e
   except ValueError as e:
-    raise BadParamError(f"Error parsing json: {e}") from e
+    raise SigoptValidationError(f"Error parsing json: {e}") from e
 
 
 class RequestProxy:
@@ -218,7 +218,7 @@ class Request(RequestBase):
       return {}
     if isinstance(e, RequestError):
       raise e
-    raise BadParamError("Malformed json in request body") from e
+    raise SigoptValidationError("Malformed json in request body") from e
 
   def params(self):
     ret = self._params
@@ -246,10 +246,10 @@ class Request(RequestBase):
         text,
         encoding=encoding,
       )
-    except BadParamError as e:
+    except SigoptValidationError as e:
       return self.on_json_loading_failed(e)
     if not isinstance(ret, dict):
-      raise BadParamError("Request body must be a JSON object")
+      raise SigoptValidationError("Request body must be a JSON object")
     return ret
 
   def optional_param(self, name):
@@ -287,7 +287,7 @@ class Request(RequestBase):
     if param_value is None:
       return None
     if not isinstance(param_value, list):
-      raise BadParamError("Invalid list value: " + param_value)
+      raise SigoptValidationError("Invalid list value: " + param_value)
     return param_value
 
   def get_sort(self, default_field, default_ascending=False):
@@ -306,9 +306,9 @@ class Request(RequestBase):
     if limit is None:
       limit = max_limit
     if limit < 0:
-      raise BadParamError(f"Invalid limit: {limit}")
+      raise InvalidValueError(f"Invalid limit: {limit}")
     if max_limit is not None and limit > max_limit:
-      raise BadParamError(f"Exceeded maximum limit: {max_limit}")
+      raise InvalidValueError(f"Exceeded maximum limit: {max_limit}")
 
     before = self._parse_marker("before")
     after = self._parse_marker("after")
@@ -324,7 +324,7 @@ class Request(RequestBase):
       return True
     if value == "0" or value.lower() == "false":
       return False
-    raise BadParamError("Invalid boolean value: " + value)
+    raise InvalidValueError("Invalid boolean value: " + value)
 
   def sanitized_params(self):
     def _sanitized_params(params):

--- a/src/python/zigopt/assignments/build.py
+++ b/src/python/zigopt/assignments/build.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache License 2.0
 from zigopt.common import *
 from zigopt.handlers.validate.assignments import get_assignment
-from zigopt.net.errors import BadParamError
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 def set_assignments_map_from_json(has_assignments_map, assignments_json, experiment):
@@ -15,14 +16,14 @@ def set_assignments_map_from_json(has_assignments_map, assignments_json, experim
         conditional_value = find(conditional.values, lambda c: c.name == assignment_json)
         # pylint: enable=cell-var-from-loop
         if conditional_value is None:
-          raise BadParamError(f"Invalid assignment {assignment_json} for conditional {conditional.name}")
+          raise SigoptValidationError(f"Invalid assignment {assignment_json} for conditional {conditional.name}")
         has_assignments_map.assignments_map[conditional.name] = conditional_value.enum_index
       elif name in experiment.all_parameters_map:
         parameter = experiment.all_parameters_map[name]
         assignment = get_assignment(parameter, assignment_json)
         has_assignments_map.assignments_map[parameter.name] = assignment
       else:
-        raise BadParamError(f'Invalid assignment, parameter does not exist: "{name}"')
+        raise SigoptValidationError(f'Invalid assignment, parameter does not exist: "{name}"')
 
 
 def set_assignments_map_from_dict(has_assignments_map, assignments_map):

--- a/src/python/zigopt/conditionals/from_json.py
+++ b/src/python/zigopt/conditionals/from_json.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: Apache License 2.0
 from zigopt.handlers.validate.experiment import validate_conditional_value
 from zigopt.handlers.validate.validate_dict import ValidationType, get_opt_with_validation, get_with_validation
-from zigopt.net.errors import BadParamError
 from zigopt.parameters.from_json import set_parameter_name_from_json
 
-from libsigopt.aux.errors import InvalidValueError
+from libsigopt.aux.errors import InvalidKeyError, InvalidValueError, MissingParamError
 
 
 def set_experiment_conditionals_list_from_json(experiment_meta, experiment_json):
@@ -25,7 +24,7 @@ def set_experiment_conditionals_list_from_json(experiment_meta, experiment_json)
     set_conditional_from_json(conditional, conditional_json)
 
     if conditional.name in seen_names:
-      raise BadParamError(f"Duplicate conditional name {conditional.name}")
+      raise InvalidKeyError(conditional.name, f"Duplicate conditional name {conditional.name}")
     seen_names.add(conditional.name)
 
 
@@ -56,8 +55,7 @@ def set_conditional_values_from_json(conditional, conditional_json):
         f"Duplicate conditional value {conditional_value.name} for conditional named {conditional.name}"
       )
     seen_values.add(conditional_value.name)
-
   if not conditional.values:
-    raise BadParamError(f"No values provided for conditional {conditional.name}")
+    raise MissingParamError(conditional.name, f"No values provided for conditional {conditional.name}")
   if len(conditional.values) < 2:
-    raise BadParamError(f"Conditional {conditional.name} must have at least 2 values")
+    raise MissingParamError(conditional.name, f"Conditional {conditional.name} must have at least 2 values")

--- a/src/python/zigopt/conditionals/util.py
+++ b/src/python/zigopt/conditionals/util.py
@@ -6,12 +6,13 @@ import itertools
 import numpy
 
 from zigopt.experiment.model import Experiment
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.gen.experiment.experimentmeta_pb2 import (
   PARAMETER_CATEGORICAL,
   ExperimentCategoricalValue,
   ExperimentParameter,
 )
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 def convert_conditional_to_categorical_parameter(conditional):
@@ -64,4 +65,4 @@ def check_all_conditional_values_satisfied(experiment_meta):
       satisfied_parameter_configurations.add(selected_conditionals)
 
   if len(satisfied_parameter_configurations) != num_conditional_values:
-    raise BadParamError("Need at least one parameter that satisfies each conditional value")
+    raise SigoptValidationError("Need at least one parameter that satisfies each conditional value")

--- a/src/python/zigopt/experiment/service.py
+++ b/src/python/zigopt/experiment/service.py
@@ -13,11 +13,11 @@ from zigopt.db.column import JsonPath, jsonb_array_length, jsonb_set, jsonb_stri
 from zigopt.experiment.constraints import InfeasibleConstraintsError, has_feasible_constraints
 from zigopt.experiment.model import Experiment
 from zigopt.math.domain_bounds import get_parameter_domain_bounds
-from zigopt.net.errors import BadParamError
 from zigopt.observation.model import Observation
 from zigopt.protobuf.gen.experiment.experimentmeta_pb2 import MetricImportance, MetricImportanceMap
 from zigopt.services.base import Service
 
+from libsigopt.aux.errors import SigoptValidationError
 from libsigopt.aux.samplers import generate_uniform_random_points_rejection_sampling
 
 
@@ -268,7 +268,7 @@ class ExperimentService(Service):
     try:
       has_feasible_constraints(experiment)
     except InfeasibleConstraintsError as e:
-      raise BadParamError(e) from e
+      raise SigoptValidationError(e) from e
 
     if experiment.experiment_meta.conditionals:
       check_all_conditional_values_satisfied(experiment.experiment_meta)

--- a/src/python/zigopt/handlers/aiexperiments/create.py
+++ b/src/python/zigopt/handlers/aiexperiments/create.py
@@ -7,8 +7,9 @@ from zigopt.handlers.projects.base import ProjectHandler
 from zigopt.handlers.validate.aiexperiment import validate_ai_experiment_json_dict_for_create
 from zigopt.handlers.validate.validate_dict import ValidationType, get_opt_with_validation
 from zigopt.json.builder import AiExperimentJsonBuilder
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import WRITE
+
+from libsigopt.aux.errors import MissingJsonKeyError
 
 
 class ClientsProjectsAiExperimentsCreateHandler(ProjectHandler, BaseExperimentsCreateHandler):
@@ -334,14 +335,14 @@ class ClientsProjectsAiExperimentsCreateHandler(ProjectHandler, BaseExperimentsC
   def get_metric_list_from_json(cls, json_dict):
     assert "metric" not in json_dict
     if not json_dict.get("metrics", []):
-      raise BadParamError(f"{cls.user_facing_class_name}s must have at least 1 metric.")
+      raise MissingJsonKeyError("metrics", f"{cls.user_facing_class_name}s must have at least 1 metric.")
     return super().get_metric_list_from_json(json_dict)
 
   @classmethod
   def get_metric_name(cls, metric, seen_names, num_metrics):
     name = super().get_metric_name(metric, seen_names, num_metrics)
     if name is None:
-      raise BadParamError("All metrics require a name")
+      raise MissingJsonKeyError("name", "All metrics require a name")
     return name
 
   @classmethod

--- a/src/python/zigopt/handlers/aiexperiments/training_runs/create.py
+++ b/src/python/zigopt/handlers/aiexperiments/training_runs/create.py
@@ -18,6 +18,8 @@ from zigopt.protobuf.gen.training_run.training_run_data_pb2 import TrainingRunDa
 from zigopt.training_run.model import OPTIMIZED_ASSIGNMENT_SOURCE, TrainingRun, is_completed_state
 from zigopt.training_run.util import get_observation_values_dict_from_training_run_values_map
 
+from libsigopt.aux.errors import SigoptValidationError
+
 
 class AiExperimentTrainingRunsCreateHandler(
   AiExperimentHandler,
@@ -41,7 +43,7 @@ class AiExperimentTrainingRunsCreateHandler(
         },
         timestamp=now,
       )
-    except BadParamError:
+    except (SigoptValidationError, BadParamError):
       return None
 
     client = self.services.client_service.find_by_id(self.experiment.client_id)
@@ -100,7 +102,7 @@ class AiExperimentTrainingRunsCreateHandler(
         processed_suggestion_meta=processed_suggestion_meta,
         automatic=True,
       )
-    except BadParamError:
+    except (SigoptValidationError, BadParamError):
       return None
 
   def maybe_create_suggestion(self, training_run_params):
@@ -123,7 +125,7 @@ class AiExperimentTrainingRunsCreateHandler(
 
   def handle(self, params):
     if self.experiment.deleted:
-      raise BadParamError(f"Cannot create training runs for deleted experiment {self.experiment.id}")
+      raise SigoptValidationError(f"Cannot create training runs for deleted experiment {self.experiment.id}")
 
     project = self.services.project_service.find_by_client_and_id(
       self.experiment.client_id,

--- a/src/python/zigopt/handlers/clients/base.py
+++ b/src/python/zigopt/handlers/clients/base.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache License 2.0
 from zigopt.common import *
 from zigopt.handlers.base.handler import Handler
-from zigopt.net.errors import BadParamError, NotFoundError
+from zigopt.net.errors import NotFoundError
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 class ClientHandler(Handler):
@@ -32,7 +34,7 @@ class ClientHandler(Handler):
       )
       if client:
         if client.deleted:
-          raise BadParamError(f"Cannot perform the requested action on deleted client {client_id}")
+          raise SigoptValidationError(f"Cannot perform the requested action on deleted client {client_id}")
         return client
     raise NotFoundError(f"No client {client_id}")
 

--- a/src/python/zigopt/handlers/clients/tokens.py
+++ b/src/python/zigopt/handlers/clients/tokens.py
@@ -10,8 +10,10 @@ from zigopt.handlers.experiments.base import ExperimentHandler
 from zigopt.handlers.training_runs.base import TrainingRunHandler
 from zigopt.handlers.validate.validate_dict import ValidationType, get_opt_with_validation
 from zigopt.json.builder import PaginationJsonBuilder, TokenJsonBuilder
-from zigopt.net.errors import BadParamError, ForbiddenError, NotFoundError
+from zigopt.net.errors import ForbiddenError, NotFoundError
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import ADMIN, READ, WRITE, TokenMeta
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 class TokenHandler(Handler):
@@ -72,7 +74,7 @@ class ClientsTokensUpdateHandler(TokenHandler):
     new_token_value = params.token
     if new_token_value is not None:
       if new_token_value != "rotate":
-        raise BadParamError('Token must equal "rotate"')
+        raise SigoptValidationError('Token must equal "rotate"')
       self.services.token_service.rotate_token(self.token)
     if params.lasts_forever is not None:
       meta = self.token.meta.copy_protobuf()
@@ -81,7 +83,7 @@ class ClientsTokensUpdateHandler(TokenHandler):
     new_expires_value = params.expires
     if new_expires_value is not None:
       if new_expires_value != "renew":
-        raise BadParamError('Expires must equal "renew"')
+        raise SigoptValidationError('Expires must equal "renew"')
       if self.token.meta.can_renew:
         self.services.token_service.renew_token(self.token)
       else:

--- a/src/python/zigopt/handlers/experiments/base.py
+++ b/src/python/zigopt/handlers/experiments/base.py
@@ -7,8 +7,10 @@ from zigopt.common import *
 from zigopt.handlers.base.handler import Handler
 from zigopt.handlers.validate.validate_dict import ValidationType, get_with_validation
 from zigopt.json.builder import ExperimentJsonBuilder
-from zigopt.net.errors import BadParamError, ForbiddenError, NotFoundError, RedirectException
+from zigopt.net.errors import ForbiddenError, NotFoundError, RedirectException
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import TokenMeta
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 def maybe_raise_for_incorrect_development_access(auth, experiment, docs_url):
@@ -37,11 +39,13 @@ def get_budget_param(json_dict, runs_only, return_key=False):
   if runs_only:
     key = BUDGET_KEY
     if OBSERVATION_BUDGET_KEY in json_dict:
-      raise BadParamError(f"{OBSERVATION_BUDGET_KEY} is no longer a valid field, please use {BUDGET_KEY} instead.")
+      raise SigoptValidationError(
+        f"{OBSERVATION_BUDGET_KEY} is no longer a valid field, please use {BUDGET_KEY} instead."
+      )
   else:
     key = OBSERVATION_BUDGET_KEY
     if BUDGET_KEY in json_dict:
-      raise BadParamError(f"{BUDGET_KEY} is not a valid field.")
+      raise SigoptValidationError(f"{BUDGET_KEY} is not a valid field.")
   budget = get_with_validation(json_dict, key, ValidationType.positive_integer)
   if return_key:
     return budget, key

--- a/src/python/zigopt/handlers/experiments/best_training_runs.py
+++ b/src/python/zigopt/handlers/experiments/best_training_runs.py
@@ -5,9 +5,10 @@ from zigopt.api.auth import api_token_authentication
 from zigopt.common.struct import ImmutableStruct
 from zigopt.handlers.experiments.base import ExperimentHandler
 from zigopt.json.builder import PaginationJsonBuilder, TrainingRunJsonBuilder
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import READ
 from zigopt.training_run.model import TrainingRun
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 # NOTE: easier to sort by ID which is monotonically increasing, so that's an appropriate proxy for created
@@ -38,7 +39,7 @@ class ExperimentsBestTrainingRunsHandler(ExperimentHandler):
     try:
       Field = SORT_FIELDS[sort.field]
     except KeyError as e:
-      raise BadParamError(f"Invalid sort: {sort.field}") from e
+      raise SigoptValidationError(f"Invalid sort: {sort.field}") from e
     return self.Params(
       paging=request.get_paging(),
       sort=sort,

--- a/src/python/zigopt/handlers/experiments/checkpoints/create.py
+++ b/src/python/zigopt/handlers/experiments/checkpoints/create.py
@@ -11,11 +11,13 @@ from zigopt.handlers.validate.checkpoint import validate_checkpoint_json_dict_fo
 from zigopt.handlers.validate.metadata import validate_metadata
 from zigopt.handlers.validate.validate_dict import ValidationType, get_opt_with_validation, get_with_validation
 from zigopt.json.builder import CheckpointJsonBuilder
-from zigopt.net.errors import BadParamError, ForbiddenError
+from zigopt.net.errors import ForbiddenError
 from zigopt.observation.data import validate_metric_names
 from zigopt.protobuf.gen.checkpoint.checkpoint_data_pb2 import CheckpointData
 from zigopt.protobuf.gen.observation.observationdata_pb2 import ObservationValue
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import WRITE
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 class CheckpointsCreateHandler(TrainingRunHandler):
@@ -58,7 +60,7 @@ class CheckpointsCreateHandler(TrainingRunHandler):
 
   def handle(self, params):
     if self.experiment and self.experiment.deleted:
-      raise BadParamError(f"Cannot create checkpoints for deleted experiment {self.experiment.id}")
+      raise SigoptValidationError(f"Cannot create checkpoints for deleted experiment {self.experiment.id}")
 
     checkpoints = self.services.checkpoint_service.find_by_training_run_id(self.training_run.id)
     max_checkpoints = self._get_max_checkpoints(self.experiment)

--- a/src/python/zigopt/handlers/experiments/create.py
+++ b/src/python/zigopt/handlers/experiments/create.py
@@ -36,7 +36,6 @@ from zigopt.handlers.validate.validate_dict import (
   key_present,
 )
 from zigopt.json.builder import ExperimentJsonBuilder
-from zigopt.net.errors import BadParamError
 from zigopt.parameters.from_json import set_experiment_parameter_list_from_json
 from zigopt.protobuf.gen.experiment.experimentmeta_pb2 import (
   PARAMETER_DOUBLE,
@@ -52,7 +51,7 @@ from zigopt.protobuf.gen.token.tokenmeta_pb2 import WRITE
 from zigopt.suggestion.sampler.grid import GridSampler
 
 from libsigopt.aux.constant import MAX_NUM_INT_CONSTRAINT_VARIABLES
-from libsigopt.aux.errors import InvalidValueError, MissingJsonKeyError
+from libsigopt.aux.errors import InvalidValueError, MissingJsonKeyError, MissingParamError, SigoptValidationError
 
 
 class BaseExperimentsCreateHandler(Handler):
@@ -107,7 +106,9 @@ class BaseExperimentsCreateHandler(Handler):
     experiment_meta = params.meta
 
     if experiment_meta.runs_only and project is None:
-      raise BadParamError(f"{self.user_facing_class_name}s must be placed in a project by defining the `project` field")
+      raise MissingParamError(
+        "project", f"{self.user_facing_class_name}s must be placed in a project by defining the `project` field"
+      )
 
     now = current_datetime()
     experiment = Experiment(
@@ -150,7 +151,7 @@ class BaseExperimentsCreateHandler(Handler):
         reference_id=reference_id,
       )
       if project is None:
-        raise BadParamError(f"Could not assign to project `{reference_id}`, the project does not exist.")
+        raise InvalidValueError(f"Could not assign to project `{reference_id}`, the project does not exist.")
       return project
     return default
 
@@ -304,7 +305,7 @@ class BaseExperimentsCreateHandler(Handler):
     )
 
     if not (has_optimization_metrics or has_constraint_metrics):
-      raise BadParamError(f"{cls.user_facing_class_name}s must have optimized or constraint metrics")
+      raise SigoptValidationError(f"{cls.user_facing_class_name}s must have optimized or constraint metrics")
 
     cls._maybe_set_tasks_for_multitask_experiment(
       json_dict,
@@ -330,7 +331,7 @@ class BaseExperimentsCreateHandler(Handler):
     objective = get_opt_with_validation(metric, "objective", ValidationType.string)
     if key_present(metric, "objective"):
       if objective is None:
-        raise BadParamError(f"Objective field, if specified, must be one of {tuple(ALL_METRIC_OBJECTIVE_NAMES)}")
+        raise InvalidValueError(f"Objective field, if specified, must be one of {tuple(ALL_METRIC_OBJECTIVE_NAMES)}")
     objective = validate_metric_objective(objective)
     return objective
 
@@ -338,7 +339,7 @@ class BaseExperimentsCreateHandler(Handler):
   def get_metric_name(cls, metric, seen_names, num_metrics):
     name = get_opt_with_validation(metric, "name", ValidationType.string)
     if name is None and num_metrics > 1:
-      raise BadParamError("Multimetric experiments do not support unnamed metrics")
+      raise SigoptValidationError("Multimetric experiments do not support unnamed metrics")
     if name in seen_names:
       raise InvalidValueError(f"Duplicate metric name: {name}")
     return name
@@ -350,16 +351,16 @@ class BaseExperimentsCreateHandler(Handler):
     has_threshold_field_and_valid_value = key_present(metric, "threshold") and threshold is not None
     if metric_strategy == ExperimentMetric.OPTIMIZE:
       if num_optimized_metrics == 1 and has_threshold_field_and_valid_value:
-        raise BadParamError(
+        raise SigoptValidationError(
           "Thresholds are only supported for experiments with more than one optimized metric."
           " Try an All-Constraint experiment instead by setting `strategy` to `constraint`."
         )
     elif metric_strategy == ExperimentMetric.CONSTRAINT:
       if not has_threshold_field_and_valid_value:
-        raise BadParamError("Constraint metrics must have the threshold field defined")
+        raise SigoptValidationError("Constraint metrics must have the threshold field defined")
     else:  # metric_strategy == ExperimentMetric.STORE
       if has_threshold_field_and_valid_value:
-        raise BadParamError("Thresholds cannot be specified on stored metrics")
+        raise SigoptValidationError("Thresholds cannot be specified on stored metrics")
 
     return threshold
 
@@ -368,7 +369,9 @@ class BaseExperimentsCreateHandler(Handler):
     metric_strategy = get_opt_with_validation(metric, "strategy", ValidationType.string)
     if key_present(metric, "strategy"):
       if metric_strategy is None:
-        raise BadParamError(f"Metric strategy field, if specified, must be one of {tuple(ALL_METRIC_STRATEGY_NAMES)}")
+        raise InvalidValueError(
+          f"Metric strategy field, if specified, must be one of {tuple(ALL_METRIC_STRATEGY_NAMES)}"
+        )
     metric_strategy = validate_metric_strategy(metric_strategy)
     return metric_strategy
 
@@ -384,16 +387,18 @@ class BaseExperimentsCreateHandler(Handler):
       assert MAX_OPTIMIZED_METRICS >= 1
       return [ExperimentMetric()]
     if not metrics:
-      raise BadParamError("The `metrics` list must contain a metric")
+      raise InvalidValueError("The `metrics` list must contain a metric")
     if len(metrics) > MAX_METRICS_ANY_STRATEGY:
-      raise BadParamError(f"Cannot have more then {MAX_METRICS_ANY_STRATEGY} metrics")
+      raise InvalidValueError(f"Cannot have more then {MAX_METRICS_ANY_STRATEGY} metrics")
     strategy_to_metrics_map = group_metric_strategies_from_json(metrics)
     optimized_metrics = strategy_to_metrics_map.get(MetricStrategyNames.OPTIMIZE, [])
     if len(optimized_metrics) > MAX_OPTIMIZED_METRICS:
-      raise BadParamError(f"{cls.user_facing_class_name}s must have at most {MAX_OPTIMIZED_METRICS} optimized metrics")
+      raise InvalidValueError(
+        f"{cls.user_facing_class_name}s must have at most {MAX_OPTIMIZED_METRICS} optimized metrics"
+      )
     constraint_metrics = strategy_to_metrics_map.get(MetricStrategyNames.CONSTRAINT, [])
     if len(constraint_metrics) > MAX_CONSTRAINT_METRICS:
-      raise BadParamError(
+      raise InvalidValueError(
         f"{cls.user_facing_class_name}s must have at most {MAX_CONSTRAINT_METRICS} constraint metrics"
       )
     seen_names = []
@@ -577,18 +582,18 @@ class BaseExperimentsCreateHandler(Handler):
       cost = get_opt_with_validation(task, "cost", ValidationType.number)
       tasks.append(Task(name=name, cost=cost))
       if cost <= 0 or cost > 1:
-        raise BadParamError("For multitask experiments, costs must all be positive and less than or equal to 1.")
+        raise InvalidValueError("For multitask experiments, costs must all be positive and less than or equal to 1.")
 
     distinct_costs = distinct([t.cost for t in tasks])
     distinct_names = distinct([t.name for t in tasks])
     if 1 not in distinct_costs:
-      raise BadParamError("For multitask experiments, exactly one task must have cost == 1 (none present).")
+      raise InvalidValueError("For multitask experiments, exactly one task must have cost == 1 (none present).")
     if len(distinct_costs) != len(tasks):
-      raise BadParamError("For multitask experiments, all task costs must be distinct.")
+      raise InvalidValueError("For multitask experiments, all task costs must be distinct.")
     if len(distinct_names) != len(tasks):
-      raise BadParamError("For multitask experiments, all task names must be distinct.")
+      raise InvalidValueError("For multitask experiments, all task names must be distinct.")
     if len(tasks) < 2:
-      raise BadParamError("For multitask experiments, at least 2 tasks must be present.")
+      raise InvalidValueError("For multitask experiments, at least 2 tasks must be present.")
 
     return tasks
 

--- a/src/python/zigopt/handlers/experiments/delete.py
+++ b/src/python/zigopt/handlers/experiments/delete.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: Apache License 2.0
 from zigopt.api.auth import api_token_authentication
 from zigopt.handlers.experiments.base import ExperimentHandler
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import WRITE
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 class ExperimentsDeleteHandler(ExperimentHandler):
@@ -60,7 +61,7 @@ class ExperimentsDeleteHandler(ExperimentHandler):
     include_runs_option = request.optional_param(self.INCLUDE_RUNS_KEY) or self.INCLUDE_RUNS_OPTION_FALSE
     include_runs_option = include_runs_option.lower()
     if include_runs_option not in self.INCLUDE_RUNS_OPTIONS:
-      raise BadParamError(f"Invalid option for {self.INCLUDE_RUNS_KEY}: {include_runs_option}")
+      raise SigoptValidationError(f"Invalid option for {self.INCLUDE_RUNS_KEY}: {include_runs_option}")
     return {self.INCLUDE_RUNS_KEY: include_runs_option}
 
   def handle(self, params):

--- a/src/python/zigopt/handlers/experiments/list_base.py
+++ b/src/python/zigopt/handlers/experiments/list_base.py
@@ -13,10 +13,11 @@ from zigopt.handlers.validate.base import validate_period
 from zigopt.handlers.validate.experiment import validate_state
 from zigopt.json.builder import AiExperimentJsonBuilder, ExperimentJsonBuilder, PaginationJsonBuilder
 from zigopt.membership.model import Membership, MembershipType
-from zigopt.net.errors import BadParamError
 from zigopt.permission.model import Permission
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import READ
 from zigopt.user.model import User
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 EXPERIMENT_RECENCY = "recent"
@@ -241,7 +242,7 @@ class BaseExperimentsListHandler(Handler):
       Field = Experiment.id
       use_having = False
     else:
-      raise BadParamError(f"Invalid sort: {params.sort.field}")
+      raise SigoptValidationError(f"Invalid sort: {params.sort.field}")
     return self.QueryArgs(query, Field, use_having, params.sort.ascending)
 
   def _issue_query(self, query_args, paging):

--- a/src/python/zigopt/handlers/experiments/suggestions/create.py
+++ b/src/python/zigopt/handlers/experiments/suggestions/create.py
@@ -7,11 +7,13 @@ from zigopt.handlers.experiments.base import ExperimentHandler
 from zigopt.handlers.experiments.create import BaseExperimentsCreateHandler
 from zigopt.handlers.validate.suggestion import validate_suggestion_json_dict_for_create
 from zigopt.json.builder import SuggestionJsonBuilder
-from zigopt.net.errors import BadParamError, ForbiddenError
+from zigopt.net.errors import ForbiddenError
 from zigopt.protobuf.gen.suggest.suggestion_pb2 import ProcessedSuggestionMeta, SuggestionMeta
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import WRITE
 from zigopt.suggestion.from_json import build_suggestion_data_from_json
 from zigopt.suggestion.unprocessed.model import SuggestionMetaProxy
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 class SuggestionsCreateHandler(ExperimentHandler):
@@ -23,7 +25,7 @@ class SuggestionsCreateHandler(ExperimentHandler):
 
   def handle(self, json_dict):
     if self.experiment.deleted:
-      raise BadParamError(f"Cannot create suggestions for deleted experiment {self.experiment.id}")
+      raise SigoptValidationError(f"Cannot create suggestions for deleted experiment {self.experiment.id}")
 
     if self.experiment.runs_only:
       raise ForbiddenError(

--- a/src/python/zigopt/handlers/organizations/invite/delete.py
+++ b/src/python/zigopt/handlers/organizations/invite/delete.py
@@ -9,8 +9,9 @@ from zigopt.handlers.organizations.base import OrganizationHandler
 from zigopt.handlers.validate.base import validate_email
 from zigopt.handlers.validate.validate_dict import ValidationType, get_with_validation
 from zigopt.iam_logging.service import IamEvent, IamResponseStatus
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import ADMIN
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 class OrganizationsUninviteHandler(OrganizationHandler):
@@ -53,16 +54,16 @@ class OrganizationsUninviteHandler(OrganizationHandler):
     invite = self.services.invite_service.find_by_email_and_organization(email, self.organization.id)
 
     if not uninvitee and not invite:
-      raise BadParamError(f"No invite exists for the email address {email}")
+      raise SigoptValidationError(f"No invite exists for the email address {email}")
 
     if uninvitee and self.services.membership_service.user_is_owner_for_organization(
       user_id=uninvitee.id,
       organization_id=self.organization.id,
     ):
-      raise BadParamError(
+      raise SigoptValidationError(
         "Once it has been accepted, the invite of an organization's owner cannot be modified."
         f" Please see your {PRODUCT_NAME} account team."
       )
 
     if uninvitee and uninvitee.id == self.auth.current_user.id:
-      raise BadParamError("You cannot modify your own role")
+      raise SigoptValidationError("You cannot modify your own role")

--- a/src/python/zigopt/handlers/organizations/invite/modify.py
+++ b/src/python/zigopt/handlers/organizations/invite/modify.py
@@ -12,9 +12,11 @@ from zigopt.handlers.validate.validate_dict import ValidationType, get_opt_with_
 from zigopt.invite.constant import NO_ROLE
 from zigopt.invite.model import Invite
 from zigopt.membership.model import MembershipType
-from zigopt.net.errors import BadParamError, ForbiddenError
+from zigopt.net.errors import ForbiddenError
 from zigopt.permission.pending.model import PendingPermission
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import ADMIN
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 class OrganizationsModifyInviteHandler(OrganizationHandler, InviteHandler):
@@ -37,7 +39,7 @@ class OrganizationsModifyInviteHandler(OrganizationHandler, InviteHandler):
     data = request.params()
 
     if "email" in data and get_with_validation(data, "email", ValidationType.string) != self.invite.email:
-      raise BadParamError("You cannot modify the email of an existing invite")
+      raise SigoptValidationError("You cannot modify the email of an existing invite")
 
     email = self.invite.email
 
@@ -54,10 +56,10 @@ class OrganizationsModifyInviteHandler(OrganizationHandler, InviteHandler):
     )
 
     if membership_type == MembershipType.owner and updated_client_invites:
-      raise BadParamError("You cannot invite an owner to specific clients")
+      raise SigoptValidationError("You cannot invite an owner to specific clients")
 
     if membership_type != MembershipType.owner and not updated_client_invites:
-      raise BadParamError("The member invite must have at least one client")
+      raise SigoptValidationError("The member invite must have at least one client")
 
     return OrganizationsModifyInviteHandler.Params(
       email=email,
@@ -93,21 +95,25 @@ class OrganizationsModifyInviteHandler(OrganizationHandler, InviteHandler):
     invitee = self.services.user_service.find_by_email(email)
 
     if any(InviteHandler.get_id_from_client_invite(invite) not in client_map for invite in client_invites):
-      raise BadParamError(f"Some of the clients aren't in the {self.organization.name} organization")
+      raise SigoptValidationError(f"Some of the clients aren't in the {self.organization.name} organization")
 
     if membership_type != MembershipType.owner and not client_invites:
-      raise BadParamError("The invitee must be invited to at least 1 client if they are not being invited as an owner")
+      raise SigoptValidationError(
+        "The invitee must be invited to at least 1 client if they are not being invited as an owner"
+      )
 
     if membership_type == MembershipType.owner and client_invites:
-      raise BadParamError("The invitee must not be invited to any clients if they are being invited as an owner")
+      raise SigoptValidationError(
+        "The invitee must not be invited to any clients if they are being invited as an owner"
+      )
 
     if not skip_existing:
       existing_invite = self.services.invite_service.find_by_email_and_organization(email, self.organization.id)
       if existing_invite:
-        raise BadParamError("This email address was already invited.")
+        raise SigoptValidationError("This email address was already invited.")
 
     if invitee and invitee.id == self.auth.current_user.id:
-      raise BadParamError("You cannot modify your own role")
+      raise SigoptValidationError("You cannot modify your own role")
 
     invite_membership = self.services.membership_service.find_by_user_and_organization(
       self.auth.current_user.id,

--- a/src/python/zigopt/handlers/organizations/update.py
+++ b/src/python/zigopt/handlers/organizations/update.py
@@ -10,9 +10,11 @@ from zigopt.handlers.validate.organization import validate_organization_name
 from zigopt.handlers.validate.validate_dict import ValidationType, get_opt_with_validation
 from zigopt.iam_logging.service import IamEvent, IamResponseStatus
 from zigopt.json.builder import OrganizationJsonBuilder
-from zigopt.net.errors import BadParamError, NotFoundError
+from zigopt.net.errors import NotFoundError
 from zigopt.organization.model import Organization
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import ADMIN, WRITE
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 class OrganizationsUpdateHandler(OrganizationHandler):
@@ -47,7 +49,7 @@ class OrganizationsUpdateHandler(OrganizationHandler):
       allow_signup_from_email_domains and not self.organization.organization_meta.allow_signup_from_email_domains
     )
     if did_enable_allow_signup and not self.services.email_verification_service.enabled:
-      raise BadParamError("Email verification is disabled, so signup from email domains cannot be enabled.")
+      raise SigoptValidationError("Email verification is disabled, so signup from email domains cannot be enabled.")
 
     return OrganizationsUpdateHandler.Params(
       name=name,
@@ -83,7 +85,7 @@ class OrganizationsUpdateHandler(OrganizationHandler):
         raise NotFoundError(f"Invalid client ID: {params.client_for_email_signup}")
 
     if meta.allow_signup_from_email_domains and not meta.email_domains:
-      raise BadParamError("If `allow_signup_from_email_domains` is true, `email_domains` must be non-empty")
+      raise SigoptValidationError("If `allow_signup_from_email_domains` is true, `email_domains` must be non-empty")
 
     if meta != self.organization.organization_meta:
       self.organization.organization_meta = meta

--- a/src/python/zigopt/handlers/projects/list.py
+++ b/src/python/zigopt/handlers/projects/list.py
@@ -5,9 +5,10 @@ from zigopt.api.auth import api_token_authentication
 from zigopt.common.struct import ImmutableStruct
 from zigopt.handlers.clients.base import ClientHandler
 from zigopt.json.builder import PaginationJsonBuilder, ProjectJsonBuilder
-from zigopt.net.errors import BadParamError
 from zigopt.project.model import Project
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import READ
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 SORT_FIELD_CREATED = "created"
@@ -92,7 +93,7 @@ class ClientsProjectsListHandler(ClientHandler):
     try:
       Field = SORT_FIELDS[sort.field]
     except KeyError as e:
-      raise BadParamError(f"Invalid sort: {sort.field}") from e
+      raise SigoptValidationError(f"Invalid sort: {sort.field}") from e
     return self.Params(
       paging=request.get_paging(),
       sort=sort,

--- a/src/python/zigopt/handlers/tags/list.py
+++ b/src/python/zigopt/handlers/tags/list.py
@@ -5,9 +5,10 @@ from zigopt.api.auth import api_token_authentication
 from zigopt.common.struct import ImmutableStruct
 from zigopt.handlers.clients.base import ClientHandler
 from zigopt.json.builder import PaginationJsonBuilder, TagJsonBuilder
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import READ
 from zigopt.tag.model import Tag
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 class ClientsTagsListHandler(ClientHandler):
@@ -27,7 +28,7 @@ class ClientsTagsListHandler(ClientHandler):
     try:
       Field = self.sort_fields[sort.field]
     except KeyError as e:
-      raise BadParamError(f"Invalid sort: {sort.field}") from e
+      raise SigoptValidationError(f"Invalid sort: {sort.field}") from e
     return self.Params(
       paging=paging,
       sort=sort,

--- a/src/python/zigopt/handlers/training_runs/files.py
+++ b/src/python/zigopt/handlers/training_runs/files.py
@@ -8,11 +8,13 @@ from zigopt.handlers.base.handler import Handler
 from zigopt.handlers.training_runs.base import TrainingRunHandler
 from zigopt.handlers.validate.validate_dict import ValidationType, get_opt_with_validation, get_with_validation
 from zigopt.json.builder import FileJsonBuilder
-from zigopt.net.errors import BadParamError, NotFoundError
+from zigopt.net.errors import NotFoundError
 from zigopt.protobuf.gen.file.filedata_pb2 import FileData
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import WRITE
 from zigopt.protobuf.gen.training_run.training_run_data_pb2 import TrainingRunData
 from zigopt.training_run.model import TrainingRun
+
+from libsigopt.aux.errors import InvalidKeyError, MissingParamError, SigoptValidationError
 
 
 training_run_files_json_name = TrainingRunData.DESCRIPTOR.fields_by_name["files"].json_name
@@ -49,7 +51,7 @@ class FileCreateHandler(Handler):
     acceptable_params = [key for key, _ in self.REQUIRED_INPUT_PARAMS + self.OPTIONAL_INPUT_PARAMS]
     unaccepted_params = provided_params.keys() - acceptable_params
     if unaccepted_params:
-      raise BadParamError(
+      raise SigoptValidationError(
         f"Unknown parameters: {unaccepted_params}. Only the following parameters are accepted: {acceptable_params}"
       )
     params = {}
@@ -58,9 +60,9 @@ class FileCreateHandler(Handler):
     for key, validator in self.OPTIONAL_INPUT_PARAMS:
       params[key] = get_opt_with_validation(provided_params, key, validator)
       if params[key] and len(params[key]) > MAX_NAME_LENGTH:
-        raise BadParamError(f"{key} must be less than {MAX_NAME_LENGTH} characters long.")
+        raise InvalidKeyError(key, f"{key} must be less than {MAX_NAME_LENGTH} characters long.")
     if not (params.get(self.PARAM_NAME) or params.get(self.PARAM_FILENAME)):
-      raise BadParamError("At least one of ('name', 'filename') is required.")
+      raise MissingParamError("filename", "At least one of ('name', 'filename') is required.")
     return params
 
   def create_file_and_json_builder(self, params, auth, client, created_by):

--- a/src/python/zigopt/handlers/training_runs/tags.py
+++ b/src/python/zigopt/handlers/training_runs/tags.py
@@ -5,10 +5,12 @@ from zigopt.api.auth import api_token_authentication
 from zigopt.handlers.training_runs.base import TrainingRunHandler
 from zigopt.handlers.validate.validate_dict import ValidationType, get_with_validation
 from zigopt.json.builder import TagJsonBuilder
-from zigopt.net.errors import BadParamError, NotFoundError, UnprocessableEntityError
+from zigopt.net.errors import NotFoundError, UnprocessableEntityError
 from zigopt.protobuf.gen.token.tokenmeta_pb2 import READ, WRITE
 from zigopt.protobuf.gen.training_run.training_run_data_pb2 import TrainingRunData
 from zigopt.training_run.model import TrainingRun
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 training_run_tags_json_name = TrainingRunData.DESCRIPTOR.fields_by_name["tags"].json_name
@@ -37,7 +39,7 @@ class TrainingRunsAddTagHandler(BaseTrainingRunsTagHandler):
     acceptable_params = [key for key, _ in self.INPUT_PARAMS]
     unaccepted_params = provided_params.keys() - acceptable_params
     if unaccepted_params:
-      raise BadParamError(
+      raise SigoptValidationError(
         f"Unknown parameters: {unaccepted_params}. Only the following parameters are accepted: {acceptable_params}"
       )
     params = {}

--- a/src/python/zigopt/handlers/users/create.py
+++ b/src/python/zigopt/handlers/users/create.py
@@ -17,6 +17,8 @@ from zigopt.protobuf.gen.token.tokenmeta_pb2 import NONE, READ, TokenMeta
 from zigopt.protobuf.gen.user.usermeta_pb2 import UserMeta
 from zigopt.user.model import User
 
+from libsigopt.aux.errors import SigoptValidationError
+
 
 class BaseUsersCreateHandler(Handler):
   UserAttributes = ImmutableStruct(
@@ -216,7 +218,7 @@ class UsersCreateHandler(BaseUsersCreateHandler):
 
     if requested_client_id:
       if invite_code:
-        raise BadParamError("Cannot provide both `client` and `invite_code`")
+        raise SigoptValidationError("Cannot provide both `client` and `invite_code`")
       pending_client = self._validate_can_signup_to_client(email, requested_client_id)
     else:
       pending_client = None

--- a/src/python/zigopt/handlers/users/update.py
+++ b/src/python/zigopt/handlers/users/update.py
@@ -9,10 +9,10 @@ from zigopt.handlers.validate.user import validate_user_email, validate_user_nam
 from zigopt.handlers.validate.validate_dict import ValidationType, get_opt_with_validation
 from zigopt.iam_logging.service import IamEvent, IamResponseStatus
 from zigopt.json.builder import UserJsonBuilder
-from zigopt.net.errors import BadParamError, ForbiddenError, NotFoundError
+from zigopt.net.errors import ForbiddenError, NotFoundError
 from zigopt.user.model import do_password_hash_work_factor_update, password_matches
 
-from libsigopt.aux.errors import MissingParamError
+from libsigopt.aux.errors import MissingParamError, SigoptValidationError
 
 
 class UsersUpdateHandler(UserHandler):
@@ -97,7 +97,7 @@ class UsersUpdateHandler(UserHandler):
     new_email = uploaded_user.email
     if new_email is not None:
       if not user.hashed_password:
-        raise BadParamError("You cannot change your email because your account is externally administered.")
+        raise SigoptValidationError("You cannot change your email because your account is externally administered.")
       if uploaded_user.password is None:
         raise MissingParamError("password")
       if not password_matches(uploaded_user.password, user.hashed_password):

--- a/src/python/zigopt/handlers/validate/assignments.py
+++ b/src/python/zigopt/handlers/validate/assignments.py
@@ -6,11 +6,11 @@ from typing import Any, Mapping
 from zigopt.experiment.constraints import human_readable_constraint
 from zigopt.experiment.model import Experiment, ExperimentParameterProxy
 from zigopt.handlers.validate.validate_dict import ValidationType, validate_type
-from zigopt.net.errors import BadParamError, ServerError
+from zigopt.net.errors import ServerError
 from zigopt.protobuf.gen.experiment.experimentmeta_pb2 import ExperimentConstraint, ExperimentParameter
 
 from libsigopt.aux.constant import ConstraintType
-from libsigopt.aux.errors import InvalidValueError
+from libsigopt.aux.errors import InvalidValueError, MissingParamError, SigoptValidationError
 
 
 def get_assignment(param: ExperimentParameterProxy, assignment: float | str) -> float | str:
@@ -19,7 +19,7 @@ def get_assignment(param: ExperimentParameterProxy, assignment: float | str) -> 
   param_name = param.name
 
   if assignment is None:
-    raise BadParamError(f"Missing assignment for parameter: {param_name}")
+    raise MissingParamError(param_name, f"Missing assignment for parameter: {param_name}")
 
   if param.is_grid:
     if assignment not in param.grid_values:
@@ -37,7 +37,7 @@ def get_assignment(param: ExperimentParameterProxy, assignment: float | str) -> 
       )
 
     if assignment_value.deleted:
-      raise BadParamError(
+      raise SigoptValidationError(
         f"Cannot report deleted categorical value {assignment} for parameter {param_name}",
       )
 
@@ -62,14 +62,14 @@ def constraint_satisfied(constraint: ExperimentConstraint, assignments_map: dict
   try:
     lhs = sum(term.coeff * assignments_map[term.name] for term in constraint.terms)
   except KeyError as e:
-    raise BadParamError(f"Term {e.args[0]} is present in constraints, but no assignment was provided") from e
+    raise SigoptValidationError(f"Term {e.args[0]} is present in constraints, but no assignment was provided") from e
 
   if constraint.type == ConstraintType.greater_than:
     if not lhs >= constraint.rhs:
-      raise BadParamError(f"Assignments do not satisfy constraint: {human_readable_constraint(constraint)}")
+      raise SigoptValidationError(f"Assignments do not satisfy constraint: {human_readable_constraint(constraint)}")
   elif constraint.type == ConstraintType.less_than:
     if not lhs <= constraint.rhs:
-      raise BadParamError(f"Assignments do not satisfy constraint: {human_readable_constraint(constraint)}")
+      raise SigoptValidationError(f"Assignments do not satisfy constraint: {human_readable_constraint(constraint)}")
   else:
     raise ServerError(f"Cannot validate assignments for constraint type: {constraint.type}")
 
@@ -77,21 +77,21 @@ def constraint_satisfied(constraint: ExperimentConstraint, assignments_map: dict
 def transformation_satisfied(parameter: ExperimentParameter, assignment: float) -> None:
   if parameter.transformation == ExperimentParameter.TRANSFORMATION_LOG:
     if assignment <= 0:
-      raise BadParamError(f"Assignment must be positive for log-transformed parameter {parameter.name}")
+      raise SigoptValidationError(f"Assignment must be positive for log-transformed parameter {parameter.name}")
 
 
 def validate_assignments_map(assignments_map: Mapping[str, Any], experiment: Experiment) -> None:
   for conditional in experiment.conditionals:
     if conditional.name not in assignments_map:
-      raise BadParamError(f'Missing assignment for conditional: "{conditional.name}"')
+      raise MissingParamError(f'Missing assignment for conditional: "{conditional.name}"')
 
   for parameter in experiment.all_parameters:
     if parameter.name not in assignments_map:
       if parameter_conditions_satisfied(parameter, assignments_map):
-        raise BadParamError(f'Missing assignment for parameter: "{parameter.name}"')
+        raise MissingParamError(parameter.name, f'Missing assignment for parameter: "{parameter.name}"')
     else:
       if not parameter_conditions_satisfied(parameter, assignments_map):
-        raise BadParamError(f'Do not provide assignment for unsatisfied parameter: "{parameter.name}"')
+        raise SigoptValidationError(f'Do not provide assignment for unsatisfied parameter: "{parameter.name}"')
 
       assignment = assignments_map[parameter.name]
       transformation_satisfied(parameter, assignment)

--- a/src/python/zigopt/handlers/validate/base.py
+++ b/src/python/zigopt/handlers/validate/base.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: Apache License 2.0
 from typing import Optional
 
-from zigopt.net.errors import BadParamError
 from zigopt.user.model import get_domain_from_email, normalize_email
+
+from libsigopt.aux.errors import InvalidValueError
 
 
 def has_invalid_chars(text: str) -> bool:
@@ -19,25 +20,25 @@ def validate_name(name: Optional[str]) -> str:
     Validates a user-entered name
     """
   if name is None:
-    raise BadParamError("Invalid name: cannot be null")
+    raise InvalidValueError("Invalid name: cannot be null")
   if name == "":
-    raise BadParamError("Invalid name: cannot be empty")
+    raise InvalidValueError("Invalid name: cannot be empty")
   if has_invalid_chars(name):
-    raise BadParamError(f"Invalid name: {name}")
+    raise InvalidValueError(f"Invalid name: {name}")
   return name.strip()
 
 
 def validate_email_domain(domain: str) -> str:
   if has_invalid_chars(domain) or "@" in domain:
-    raise BadParamError(f"Invalid email domain: {domain}")
+    raise InvalidValueError(f"Invalid email domain: {domain}")
   return normalize_email(domain)
 
 
 def validate_email(email: Optional[str]) -> str:
   if email is None:
-    raise BadParamError("Invalid email: cannot be null")
+    raise InvalidValueError("Invalid email: cannot be null")
   if has_invalid_chars(email) or "@" not in email:
-    raise BadParamError(f"Invalid email: {email}")
+    raise InvalidValueError(f"Invalid email: {email}")
   validate_email_domain(get_domain_from_email(email))
   return normalize_email(email)
 
@@ -47,10 +48,10 @@ def validate_period(start: Optional[int], end: Optional[int]) -> tuple[Optional[
     Validates a period of time, as specified by a start and end timestamp
     """
   if start and start < 0:
-    raise BadParamError("Invalid period start timestamp: cannot be less than 0")
+    raise InvalidValueError("Invalid period start timestamp: cannot be less than 0")
   if end and end < 0:
-    raise BadParamError("Invalid period end timestamp: cannot be less than 0")
+    raise InvalidValueError("Invalid period end timestamp: cannot be less than 0")
   if start and end and end < start:
-    raise BadParamError("Invalid period range: end timestamp cannot be before start timestamp")
+    raise InvalidValueError("Invalid period range: end timestamp cannot be before start timestamp")
 
   return (start, end)

--- a/src/python/zigopt/handlers/validate/client.py
+++ b/src/python/zigopt/handlers/validate/client.py
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: Apache License 2.0
 from zigopt.client.model import Client
 from zigopt.handlers.validate.base import validate_name
-from zigopt.net.errors import BadParamError
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 def validate_client_name(name: str) -> str:
   name = validate_name(name)
   if len(name) >= Client.NAME_MAX_LENGTH:
-    raise BadParamError(f"Name must be fewer than {Client.NAME_MAX_LENGTH} characters")
+    raise SigoptValidationError(f"Name must be fewer than {Client.NAME_MAX_LENGTH} characters")
   return name

--- a/src/python/zigopt/handlers/validate/experiment.py
+++ b/src/python/zigopt/handlers/validate/experiment.py
@@ -14,9 +14,9 @@ from zigopt.experiment.constant import (
 from zigopt.experiment.model import Experiment
 from zigopt.handlers.validate.base import validate_name
 from zigopt.handlers.validate.project import PROJECT_ID_SCHEMA as _PROJECT_ID_SCHEMA
-from zigopt.net.errors import BadParamError
 
 from libsigopt.aux.constant import ConstraintType
+from libsigopt.aux.errors import MissingParamError, SigoptValidationError
 from libsigopt.aux.validate_schema import validate
 
 
@@ -251,11 +251,11 @@ def validate_name_length(obj_type: str, name: Optional[str]) -> str:
     name = validate_name(name)
     max_len = Experiment.CATEGORICAL_VALUE_MAX_LENGTH if obj_type == "Categorical" else Experiment.NAME_MAX_LENGTH
     if not name:
-      raise BadParamError(f"{obj_type} names cannot be empty")
+      raise MissingParamError("names", f"{obj_type} names cannot be empty")
     if len(name) > max_len:
-      raise BadParamError(f"{obj_type} names must be less than {max_len} characters")
+      raise SigoptValidationError(f"{obj_type} names must be less than {max_len} characters")
     return name
-  raise BadParamError(f"Unrecognized object type: {obj_type}")
+  raise SigoptValidationError(f"Unrecognized object type: {obj_type}")
 
 
 def validate_experiment_name(name: Optional[str]) -> str:
@@ -279,7 +279,7 @@ def validate_metric_objective(objective: Optional[str]) -> Optional[int]:
     return METRIC_OBJECTIVE_NAME_TO_TYPE[objective]
   if objective is None:
     return None
-  raise BadParamError(
+  raise SigoptValidationError(
     f"Unrecognized objective type: {objective} (If provided, must be one of {tuple(ALL_METRIC_OBJECTIVE_NAMES)})"
   )
 
@@ -289,7 +289,7 @@ def validate_metric_strategy(strategy: Optional[str]) -> Optional[int]:
     return METRIC_STRATEGY_NAME_TO_TYPE[strategy]
   if strategy is None:
     return None
-  raise BadParamError(
+  raise SigoptValidationError(
     f"Unrecognized strategy: {strategy}. If provided, must be one of {tuple(ALL_METRIC_STRATEGY_NAMES)}"
   )
 
@@ -304,5 +304,5 @@ def validate_conditional_value(name: Optional[str]) -> str:
 
 def validate_state(state: Optional[str]) -> Optional[str]:
   if state and state not in ("deleted", "active"):
-    raise BadParamError(f'Unrecognized state {state} (if provided, must be one of ("deleted", "active")')
+    raise SigoptValidationError(f'Unrecognized state {state} (if provided, must be one of ("deleted", "active")')
   return state

--- a/src/python/zigopt/handlers/validate/membership.py
+++ b/src/python/zigopt/handlers/validate/membership.py
@@ -4,12 +4,13 @@
 from typing import Optional
 
 from zigopt.membership.model import MembershipType
-from zigopt.net.errors import BadParamError
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 def validate_membership_type(membership_type: Optional[str]) -> Optional[MembershipType]:
   if membership_type and membership_type not in MembershipType.__members__:
-    raise BadParamError(
+    raise SigoptValidationError(
       f"Unrecognized membership type {membership_type} (if provided, must be one of {list(MembershipType.__members__)}"
     )
   return MembershipType[membership_type] if membership_type else None

--- a/src/python/zigopt/handlers/validate/metadata.py
+++ b/src/python/zigopt/handlers/validate/metadata.py
@@ -8,9 +8,9 @@ from google.protobuf.struct_pb2 import Struct  # pylint: disable=no-name-in-modu
 
 from zigopt.common import *
 from zigopt.experiment.model import Experiment
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.dict import dict_to_protobuf_struct, is_protobuf_struct, protobuf_struct_to_dict
 
+from libsigopt.aux.errors import SigoptValidationError
 from libsigopt.aux.validate_schema import validate
 
 
@@ -30,7 +30,7 @@ def _schema_validate(metadata: dict[str, Any], length: int, key_length: int, max
   for key in metadata:
     if len(key) > key_length:
       key_str = f"{key[:10]}...{key[-10:]}" if len(key) > 20 else key
-      raise BadParamError(f"The length of the metadata key '{key_str}' must be less than {key_length}")
+      raise SigoptValidationError(f"The length of the metadata key '{key_str}' must be less than {key_length}")
 
 
 def validate_custom_json(metadata: dict[str, Any]) -> Optional[str]:

--- a/src/python/zigopt/handlers/validate/observation.py
+++ b/src/python/zigopt/handlers/validate/observation.py
@@ -14,11 +14,10 @@ from zigopt.handlers.validate.validate_dict import (
   validate_mutually_exclusive_properties,
 )
 from zigopt.handlers.validate.values import base_values_schema
-from zigopt.net.errors import BadParamError
 from zigopt.observation.model import Observation
 from zigopt.task.from_json import extract_task_from_json
 
-from libsigopt.aux.errors import MissingJsonKeyError
+from libsigopt.aux.errors import InvalidValueError, MissingJsonKeyError, SigoptValidationError
 from libsigopt.aux.validate_schema import validate
 
 
@@ -52,11 +51,11 @@ def validate_observation_json_dict_for_create(json_dict: dict[str, Any], experim
   validate(json_dict, observation_schema)
 
   if get_opt_with_validation(json_dict, "failed", ValidationType.boolean) is True and json_dict.get("values"):
-    raise BadParamError("Cannot provide `values` if observation has failed")
+    raise SigoptValidationError("Cannot provide `values` if observation has failed")
 
   validate_mutually_exclusive_properties(json_dict, ["suggestion", "assignments"])
   if not (key_present(json_dict, "suggestion") or key_present(json_dict, "assignments")):
-    raise BadParamError(f"Must provide exactly one of `suggestion`, `assignments` in: {json.dumps(json_dict)}")
+    raise SigoptValidationError(f"Must provide exactly one of `suggestion`, `assignments` in: {json.dumps(json_dict)}")
 
   if json_dict.get("failed") is not True:
     if json_dict.get("value") is None and not json_dict.get("values"):
@@ -68,9 +67,9 @@ def validate_observation_json_dict_for_create(json_dict: dict[str, Any], experim
 
   if json_dict.get("values") is not None:
     if json_dict.get("value") is not None:
-      raise BadParamError("Both 'value' and 'values' should not be specified.")
+      raise SigoptValidationError("Both 'value' and 'values' should not be specified.")
     if json_dict.get("value_stddev"):
-      raise BadParamError("'value_stddev' should be specified within the 'values' list.")
+      raise InvalidValueError("'value_stddev' should be specified within the 'values' list.")
 
 
 def _get_assignments(json_dict, experiment, observation):
@@ -100,7 +99,7 @@ def validate_observation_json_dict_for_update(
   assignments = _get_assignments(json_dict, experiment, observation)
 
   if (suggestion is not None and assignments is not None) or (suggestion is None and assignments is None):
-    raise BadParamError("Must provide exactly one of `suggestion`, `assignments`")
+    raise SigoptValidationError("Must provide exactly one of `suggestion`, `assignments`")
 
   failed = json_dict["failed"] if key_present(json_dict, "failed") else observation.reported_failure
   if experiment.has_multiple_metrics:
@@ -108,9 +107,9 @@ def validate_observation_json_dict_for_update(
       json_dict["values"] if key_present(json_dict, "values") else observation.get_all_measurements(experiment)
     )
     if measurements is not None and failed is True:
-      raise BadParamError("Multimetric observations with values cannot have failed == true")
+      raise SigoptValidationError("Multimetric observations with values cannot have failed == true")
     if measurements is None and failed is not True:
-      raise BadParamError("Multimetric observations must either have values or failed == true")
+      raise SigoptValidationError("Multimetric observations must either have values or failed == true")
   else:
     only_metric_name = experiment.all_metrics[0].name
     value = (
@@ -122,8 +121,8 @@ def validate_observation_json_dict_for_update(
     )
 
     if value is not None and failed is True:
-      raise BadParamError("Observations with a value cannot have failed == true")
+      raise SigoptValidationError("Observations with a value cannot have failed == true")
     if value is None and failed is not True:
-      raise BadParamError("Observations must either have a value or failed == true")
+      raise SigoptValidationError("Observations must either have a value or failed == true")
 
   _validate_task(json_dict, experiment)

--- a/src/python/zigopt/handlers/validate/observation.py
+++ b/src/python/zigopt/handlers/validate/observation.py
@@ -84,7 +84,7 @@ def _validate_task(json_dict, experiment):
   if not key_present(json_dict, "task"):
     return
   if not experiment.is_multitask:
-    raise BadParamError("Only multitask experiments should have a task present.")
+    raise SigoptValidationError("Only multitask experiments should have a task present.")
   if json_dict["task"] is not None:
     # This will error if the task is unacceptable
     extract_task_from_json(experiment, json_dict)

--- a/src/python/zigopt/handlers/validate/organization.py
+++ b/src/python/zigopt/handlers/validate/organization.py
@@ -4,12 +4,13 @@
 from typing import Optional
 
 from zigopt.handlers.validate.base import validate_name
-from zigopt.net.errors import BadParamError
 from zigopt.organization.model import Organization
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 def validate_organization_name(name: Optional[str]) -> str:
   name = validate_name(name)
   if len(name) >= Organization.NAME_MAX_LENGTH:
-    raise BadParamError(f"Name must be fewer than {Organization.NAME_MAX_LENGTH} characters")
+    raise SigoptValidationError(f"Name must be fewer than {Organization.NAME_MAX_LENGTH} characters")
   return name

--- a/src/python/zigopt/handlers/validate/role.py
+++ b/src/python/zigopt/handlers/validate/role.py
@@ -4,16 +4,17 @@
 from typing import Optional
 
 from zigopt.invite.constant import ALL_ROLES, NO_ROLE
-from zigopt.net.errors import BadParamError
+
+from libsigopt.aux.errors import InvalidValueError
 
 
 def validate_role(role: Optional[str]) -> Optional[str]:
   if role is None or role in ALL_ROLES:
     return role
-  raise BadParamError(f"Invalid role: `{role}`")
+  raise InvalidValueError(f"Invalid role: `{role}`")
 
 
 def validate_invite_role(role: Optional[str]) -> Optional[str]:
   if role is None or role in ALL_ROLES and role != NO_ROLE:
     return role
-  raise BadParamError(f"Invalid invite role: `{role}`")
+  raise InvalidValueError(f"Invalid invite role: `{role}`")

--- a/src/python/zigopt/handlers/validate/suggestion.py
+++ b/src/python/zigopt/handlers/validate/suggestion.py
@@ -5,12 +5,13 @@ from typing import Any, Optional
 
 from zigopt.experiment.model import Experiment
 from zigopt.handlers.validate.validate_dict import key_present
-from zigopt.net.errors import BadParamError
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 def validate_state(state: Optional[str]) -> Optional[str]:
   if state and state != "open":
-    raise BadParamError(f"Unrecognized state {state} (if provided, must be open)")
+    raise SigoptValidationError(f"Unrecognized state {state} (if provided, must be open)")
   return state
 
 
@@ -19,9 +20,9 @@ def validate_suggestion_json_dict_for_create(json_dict: dict[str, Any], experime
     if (key_present(json_dict, "assignments") and not key_present(json_dict, "task")) or (
       key_present(json_dict, "task") and not key_present(json_dict, "assignments")
     ):
-      raise BadParamError(
+      raise SigoptValidationError(
         "For multitask experiments, manually created suggestions must have both `assignments` and `task`"
       )
   else:
     if key_present(json_dict, "task"):
-      raise BadParamError("`task` should only be present for multitask experiments")
+      raise SigoptValidationError("`task` should only be present for multitask experiments")

--- a/src/python/zigopt/handlers/validate/sys_metadata.py
+++ b/src/python/zigopt/handlers/validate/sys_metadata.py
@@ -1,8 +1,9 @@
 # Copyright © 2022 Intel Corporation
 #
 # SPDX-License-Identifier: Apache License 2.0
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.gen.training_run.training_run_data_pb2 import FeatureImportances, SysMetadata
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 FEATURE_IMPORTANCES_MAX_NUM_FEATURE = 50
@@ -19,13 +20,13 @@ def validate_feature_importances(feature_importances: FeatureImportances) -> Non
   for key in feature_importances.scores:
     if len(key) > key_length:
       key_str = f"{key[:10]}...{key[-10:]}"
-      raise BadParamError(
+      raise SigoptValidationError(
         f"The length of the feature_importances scores key '{key_str}' must be less than or equal to {key_length}"
       )
   key = feature_importances.type
   if len(key) > key_length:
     key_str = f"{key[:10]}...{key[-10:]}"
-    raise BadParamError(
+    raise SigoptValidationError(
       f"The length of the feature_importances type '{key_str}' must be less than or equal to {key_length}"
     )
 

--- a/src/python/zigopt/handlers/validate/training_run.py
+++ b/src/python/zigopt/handlers/validate/training_run.py
@@ -3,9 +3,10 @@
 # SPDX-License-Identifier: Apache License 2.0
 from typing import Any, Mapping, Optional
 
-from zigopt.net.errors import BadParamError
 from zigopt.training_run.constant import TRAINING_RUN_JSON_TO_STATE
 from zigopt.training_run.model import OPTIMIZED_ASSIGNMENT_SOURCE, TrainingRun
+
+from libsigopt.aux.errors import InvalidKeyError, InvalidValueError, SigoptValidationError
 
 
 MAX_SOURCE_LENGTH = 30
@@ -13,18 +14,18 @@ MAX_SOURCE_LENGTH = 30
 
 def validate_state(state_string: Optional[str]) -> str:
   if state_string is None:
-    raise BadParamError("Invalid state: cannot be null")
+    raise InvalidValueError("Invalid state: cannot be null")
   try:
     state = TRAINING_RUN_JSON_TO_STATE[state_string]
   except KeyError as e:
-    raise BadParamError(f"Invalid state: {state_string}") from e
+    raise InvalidValueError(f"Invalid state: {state_string}") from e
   return state
 
 
 def validate_assignments_meta_json(assignments_meta: dict[str, dict[str, Any]]) -> None:
   for param, meta in assignments_meta.items():
     if len(meta["source"]) > MAX_SOURCE_LENGTH:
-      raise BadParamError(
+      raise SigoptValidationError(
         f"The source {meta['source']} is over the maximum length of {MAX_SOURCE_LENGTH}"
         f" characters for the parameter {param}"
       )
@@ -33,7 +34,9 @@ def validate_assignments_meta_json(assignments_meta: dict[str, dict[str, Any]]) 
 def validate_assignments_sources_json(assignment_sources: dict[str, Any]) -> None:
   for key in assignment_sources.keys():
     if len(key) > MAX_SOURCE_LENGTH:
-      raise BadParamError(f" {key} is over the maximum length of {key} characters for a parameter source.")
+      raise InvalidKeyError(
+        key, f" {key} is over the maximum length of {MAX_SOURCE_LENGTH} characters for a parameter source."
+      )
 
 
 def validate_assignments_meta(
@@ -48,8 +51,10 @@ def validate_assignments_meta(
     params += [*dict(training_run.training_run_data.assignments_struct)]
 
   if OPTIMIZED_ASSIGNMENT_SOURCE in sources:
-    raise BadParamError(f" {OPTIMIZED_ASSIGNMENT_SOURCE} source is reserved and set automatically.")
+    raise SigoptValidationError(f" {OPTIMIZED_ASSIGNMENT_SOURCE} source is reserved and set automatically.")
 
   metas_without_param = set(meta_keys) - set(params)
   if metas_without_param:
-    raise BadParamError(f" Parameter meta exist for {metas_without_param} but there is no corresponding parameter.")
+    raise SigoptValidationError(
+      f" Parameter meta exist for {metas_without_param} but there is no corresponding parameter."
+    )

--- a/src/python/zigopt/handlers/validate/user.py
+++ b/src/python/zigopt/handlers/validate/user.py
@@ -4,23 +4,24 @@
 from typing import Optional
 
 from zigopt.handlers.validate.base import validate_email, validate_name
-from zigopt.net.errors import BadParamError
 from zigopt.user.model import User
+
+from libsigopt.aux.errors import InvalidValueError, MissingParamError
 
 
 def validate_user_name(name: Optional[str]) -> str:
   name = validate_name(name)
   if name:
     if len(name) >= User.NAME_MAX_LENGTH:
-      raise BadParamError(f"Name must be fewer than {User.NAME_MAX_LENGTH} characters")
+      raise InvalidValueError(f"Name must be fewer than {User.NAME_MAX_LENGTH} characters")
     return name
-  raise BadParamError("User name is required")
+  raise MissingParamError("name", "User name is required")
 
 
 def validate_user_email(email: Optional[str]) -> str:
   email = validate_email(email)
   if len(email) >= User.EMAIL_MAX_LENGTH:
-    raise BadParamError(f"Email must be fewer than {User.EMAIL_MAX_LENGTH} characters")
+    raise InvalidValueError(f"Email must be fewer than {User.EMAIL_MAX_LENGTH} characters")
   return email
 
 
@@ -31,7 +32,7 @@ def validate_user_password(plaintext_password: str) -> str:
   # used to check if the password is correct.
   # We could count bytes, but conveying that to the user in an error message would be annoying
   if len(plaintext_password) >= User.PASSWORD_MAX_LENGTH_BYTES:
-    raise BadParamError(f"Password must be fewer than {User.PASSWORD_MAX_LENGTH_BYTES} characters")
+    raise InvalidValueError(f"Password must be fewer than {User.PASSWORD_MAX_LENGTH_BYTES} characters")
 
   is_long_enough = len(plaintext_password) >= User.PASSWORD_MIN_LENGTH_CHARACTERS
   has_num = any((c.isnumeric() for c in plaintext_password))
@@ -39,7 +40,7 @@ def validate_user_password(plaintext_password: str) -> str:
   has_upper = any((c.isupper() for c in plaintext_password))
   has_special = any((not c.isalnum() for c in plaintext_password))
   if not all((is_long_enough, has_num, has_lower, has_upper, has_special)):
-    raise BadParamError(
+    raise InvalidValueError(
       "Password must be"
       f" more than {User.PASSWORD_MIN_LENGTH_CHARACTERS} characters"
       ", and contain an uppercase character, a lowercase character, a digit, and a special character."

--- a/src/python/zigopt/handlers/validate/web_data/base.py
+++ b/src/python/zigopt/handlers/validate/web_data/base.py
@@ -8,10 +8,10 @@ from zigopt.common import *
 from zigopt.handlers.validate.validate_dict import ValidationType, get_with_validation
 from zigopt.handlers.validate.web_data.ag_run_view import ag_run_view_schema
 from zigopt.handlers.validate.web_data.run_view import run_view_schema
-from zigopt.net.errors import BadParamError
 from zigopt.web_data.lib import validate_web_data_dict
 from zigopt.web_data.model import MAX_DISPLAY_NAME_LENGTH, web_data_types_by_resource
 
+from libsigopt.aux.errors import SigoptValidationError
 from libsigopt.aux.validate_schema import validate
 
 
@@ -69,7 +69,9 @@ validate_web_data_dict(parent_id_validator_by_resource, depth=1)
 def validate_resource_exists(parent_resource_type, web_data_type):
   test = schema_by_resource.get(parent_resource_type, {}).get(web_data_type, None)
   if test is None:
-    raise BadParamError(f"Could not find web data type: `{web_data_type}` for resource: `{parent_resource_type}`")
+    raise SigoptValidationError(
+      f"Could not find web data type: `{web_data_type}` for resource: `{parent_resource_type}`"
+    )
 
 
 def validate_web_data_parent_resource_id(params):

--- a/src/python/zigopt/handlers/web_data/base.py
+++ b/src/python/zigopt/handlers/web_data/base.py
@@ -6,8 +6,9 @@ import json
 from zigopt.common import *
 from zigopt.handlers.base.handler import Handler
 from zigopt.handlers.validate.web_data.base import validate_web_data_parent_resource_id
-from zigopt.net.errors import BadParamError
 from zigopt.web_data.lib import validate_web_data_dict
+
+from libsigopt.aux.errors import SigoptValidationError
 
 
 web_data_limits = {"project": {"run_view": 100, "ag_run_view": 100}}
@@ -24,14 +25,14 @@ class WebDataBaseHandler(Handler):
 
     parent_resource_id = params.get("parent_resource_id", None)
     if parent_resource_id is None:
-      raise BadParamError("No parent_resource_id set.")
+      raise SigoptValidationError("No parent_resource_id set.")
 
     # For list/delete parent_resource_id is stringified to fit inside query params
     if is_string(parent_resource_id):
       try:
         params["parent_resource_id"] = json.loads(parent_resource_id)
       except Exception as e:
-        raise BadParamError("parent_resource_id should be a string id or JSON object for projects") from e
+        raise SigoptValidationError("parent_resource_id should be a string id or JSON object for projects") from e
 
     validate_web_data_parent_resource_id(params)
     can_act_on_resource = {

--- a/src/python/zigopt/observation/from_json.py
+++ b/src/python/zigopt/observation/from_json.py
@@ -6,9 +6,10 @@ from enum import Enum
 from zigopt.assignments.build import set_assignments_map_from_json, set_assignments_map_from_proxy
 from zigopt.handlers.validate.assignments import validate_assignments_map
 from zigopt.handlers.validate.validate_dict import ValidationType, get_opt_with_validation
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.lib import CopyFrom
 from zigopt.task.from_json import extract_task_from_json
+
+from libsigopt.aux.errors import InvalidValueError, SigoptValidationError
 
 
 # This allows someone to pass just the task of a MT observation, not necessarily the assignments.
@@ -26,25 +27,27 @@ def set_observation_data_assignments_task_from_json(
 
   if suggestion_json is None and assignments_json is None:
     if experiment.is_multitask:
-      raise BadParamError("Either `suggestion` or `assignments`+`task` must be provided when creating an observation")
-    raise BadParamError("Must provide values for one of `suggestion` or `assignments`")
+      raise SigoptValidationError(
+        "Either `suggestion` or `assignments`+`task` must be provided when creating an observation"
+      )
+    raise SigoptValidationError("Must provide values for one of `suggestion` or `assignments`")
   if suggestion_json is not None and assignments_json is not None:
-    raise BadParamError("Cannot provide values for both `suggestion` and `assignments`")
+    raise SigoptValidationError("Cannot provide values for both `suggestion` and `assignments`")
   if suggestion_json is not None and assignments_json is None:
     if task_field_present:
-      raise BadParamError("Cannot provide/update `task` when `suggestion` is provided")
+      raise SigoptValidationError("Cannot provide/update `task` when `suggestion` is provided")
     set_observation_suggestion_from_json(observation_data, observation, suggestion_json, experiment, suggestion)
   else:
     set_observation_data_assignments_map_from_json(observation_data, json_dict, experiment)
     if experiment.is_multitask:
       if not task_field_present:
-        raise BadParamError("Must provide `assignments` and `task` when creating observations manually")
+        raise SigoptValidationError("Must provide `assignments` and `task` when creating observations manually")
       set_observation_data_task_from_json(observation_data, json_dict, experiment)
 
 
 def set_observation_suggestion_from_json(observation_data, observation, suggestion_json, experiment, suggestion):
   if suggestion is None or suggestion.experiment_id != experiment.id:
-    raise BadParamError(f"No suggestion: {suggestion_json} for experiment: {experiment.id}")
+    raise InvalidValueError(f"No suggestion: {suggestion_json} for experiment: {experiment.id}")
 
   observation.processed_suggestion_id = suggestion.id
   observation_data.ClearField("assignments_map")
@@ -58,7 +61,7 @@ def set_observation_data_assignments_map_from_json(observation_data, json_dict, 
   assignments_json = get_opt_with_validation(json_dict, "assignments", ValidationType.object)
 
   if not assignments_json:
-    raise BadParamError("Cannot provide null or empty `assignments`")
+    raise SigoptValidationError("Cannot provide null or empty `assignments`")
 
   observation_data.ClearField("assignments_map")
   set_assignments_map_from_json(observation_data, assignments_json, experiment)
@@ -91,21 +94,21 @@ def _get_suggestion_assignments_update_type(update_suggestion: bool, update_assi
 def _check_suggestion_assignments_update(update, suggestion_json, assignments_json, observation):
   if update is SuggestionAssignmentUpdates.BOTH:
     if suggestion_json is None and assignments_json is None:
-      raise BadParamError("Cannot provide null for both `suggestion` and `assignments`")
+      raise SigoptValidationError("Cannot provide null for both `suggestion` and `assignments`")
     if suggestion_json is not None and assignments_json is not None:
-      raise BadParamError("Cannot set values for both `suggestion` and `assignments`")
+      raise SigoptValidationError("Cannot set values for both `suggestion` and `assignments`")
     return
   if update is SuggestionAssignmentUpdates.SUGGESTION_ONLY:
     if observation.has_suggestion and suggestion_json is None:
-      raise BadParamError("Cannot provide null for `suggestion` without providing `assignments`")
+      raise SigoptValidationError("Cannot provide null for `suggestion` without providing `assignments`")
     if not observation.has_suggestion and suggestion_json is not None:
-      raise BadParamError("Cannot provide `suggestion` without providing null for `assignments`")
+      raise SigoptValidationError("Cannot provide `suggestion` without providing null for `assignments`")
     return
   if update is SuggestionAssignmentUpdates.ASSIGNMENTS_ONLY:
     if not observation.has_suggestion and assignments_json is None:
-      raise BadParamError("Cannot provide null for `assignments` without providing `suggestion`")
+      raise SigoptValidationError("Cannot provide null for `assignments` without providing `suggestion`")
     if observation.has_suggestion and assignments_json is not None:
-      raise BadParamError("Cannot provide `assignments` without providing null not `suggestion`")
+      raise SigoptValidationError("Cannot provide `assignments` without providing null not `suggestion`")
     return
 
 
@@ -116,14 +119,18 @@ def _check_task_update(json_dict, experiment, suggestion_json, assignments_json,
     if task_field_present:
       if assignments_json is None and json_dict["task"] is not None:
         if suggestion_json is None and observation_has_processed_suggestion:
-          raise BadParamError("Cannot provide `task` for observation update for observation with associated suggestion")
+          raise SigoptValidationError(
+            "Cannot provide `task` for observation update for observation with associated suggestion"
+          )
         if suggestion_json is not None:
-          raise BadParamError("Cannot provide `task` when updating observation to change associated suggestion")
+          raise SigoptValidationError("Cannot provide `task` when updating observation to change associated suggestion")
     else:
       if observation_has_processed_suggestion and suggestion_json is None and assignments_json is not None:
-        raise BadParamError("Most provide both `task` and `assignments` when updating observation to remove suggestion")
+        raise SigoptValidationError(
+          "Most provide both `task` and `assignments` when updating observation to remove suggestion"
+        )
   elif task_field_present:
-    raise BadParamError(f"Cannot provide `task` for experiment {experiment.id} which is not multitask")
+    raise SigoptValidationError(f"Cannot provide `task` for experiment {experiment.id} which is not multitask")
 
 
 def update_observation_data_assignments_task_from_json(

--- a/src/python/zigopt/parameters/from_json.py
+++ b/src/python/zigopt/parameters/from_json.py
@@ -274,10 +274,10 @@ def set_default_value_from_json(parameter, parameter_json):
     value_to_set = get_assignment(parameter, default_value)
     parameter.replacement_value_if_missing = value_to_set
 
-  if parameter.transformation == ExperimentParameter.TRANSFORMATION_LOG:
-    assert isinstance(parameter.replacement_value_if_missing, float)
-    if parameter.replacement_value_if_missing <= 0.0:
-      raise SigoptValidationError("Invalid default_value for log-transformation: default_value must be positive")
+    if parameter.transformation == ExperimentParameter.TRANSFORMATION_LOG:
+      assert isinstance(parameter.replacement_value_if_missing, float)
+      if parameter.replacement_value_if_missing <= 0.0:
+        raise SigoptValidationError("Invalid default_value for log-transformation: default_value must be positive")
 
 
 def set_parameter_conditions_from_json(parameter, parameter_json, conditionals_map):

--- a/src/python/zigopt/task/from_json.py
+++ b/src/python/zigopt/task/from_json.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache License 2.0
 from zigopt.handlers.validate.validate_dict import ValidationType, get_opt_with_validation
-from zigopt.net.errors import BadParamError
+
+from libsigopt.aux.errors import InvalidKeyError, SigoptValidationError
 
 
 def extract_task_from_json(experiment, json_dict):
@@ -16,11 +17,11 @@ def extract_task_from_json(experiment, json_dict):
   else:
     task_name = task_field
   if task_name is None:
-    raise BadParamError("A task name must be defined when creating suggestions for a multitask experiment.")
+    raise InvalidKeyError("name", "A task name must be defined when creating suggestions for a multitask experiment.")
 
   try:
     task = experiment.get_task_by_name(task_name)
   except ValueError as e:
-    raise BadParamError(str(e)) from e
+    raise SigoptValidationError(str(e)) from e
 
   return task.copy_protobuf()

--- a/test/integration/v1/requests/api_test.py
+++ b/test/integration/v1/requests/api_test.py
@@ -111,7 +111,7 @@ class TestApiBase(V1Base):
       data="{",
     )
     assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert "Invalid json" in response.json()["message"]
+    assert "Malformed json in request body" in response.json()["message"]
 
   def test_post_read_params_json(self, api_url, headers, auth):
     response = secure_request(

--- a/test/integration/v1/requests/parsing_test.py
+++ b/test/integration/v1/requests/parsing_test.py
@@ -32,4 +32,4 @@ class TestRequestParsing(V1Base):
   def test_json_float_bad_request(self, api_url, invalid_float):
     response = request("POST", f"{api_url}/v1/clients", data=f'{{"name": {invalid_float}}}')
     assert response.status_code == HTTPStatus.BAD_REQUEST
-    assert response.json()["message"].startswith("Invalid json")
+    assert response.json()["message"].startswith("Malformed json in request body")

--- a/test/python/sigopttest/api/common.py
+++ b/test/python/sigopttest/api/common.py
@@ -8,7 +8,9 @@ import json
 import pytest
 
 from zigopt.api import request
-from zigopt.net.errors import BadParamError
+from zigopt.api.request import InvalidJsonValue
+
+from libsigopt.aux.errors import InvalidKeyError, SigoptValidationError
 
 
 class TestJsonHandling:
@@ -21,11 +23,11 @@ class TestJsonHandling:
 
     assert request.object_pairs_hook_raise_on_duplicates(no_dupes) == dict(no_dupes)
 
-    with pytest.raises(BadParamError):
+    with pytest.raises(InvalidKeyError):
       request.object_pairs_hook_raise_on_duplicates(dupes)
 
   def test_overflow_json_value(self):
-    with pytest.raises(BadParamError):
+    with pytest.raises(InvalidJsonValue):
       request.as_json('{"a":1e+400}'.encode())
 
   def test_as_json(self):
@@ -41,11 +43,11 @@ class TestJsonHandling:
     dupes_json = json.loads(dupes_str)
     assert dupes_json["hi"] == 3
 
-    with pytest.raises(BadParamError):
+    with pytest.raises(InvalidKeyError):
       request.as_json(dupes_str.encode())
 
     bad_str = b"{"
-    with pytest.raises(BadParamError):
+    with pytest.raises(SigoptValidationError):
       request.as_json(bad_str)
 
   def test_unicode(self):

--- a/test/python/sigopttest/conditionals/from_json.py
+++ b/test/python/sigopttest/conditionals/from_json.py
@@ -4,10 +4,9 @@
 import pytest
 
 from zigopt.conditionals.from_json import set_conditional_from_json, set_experiment_conditionals_list_from_json
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.gen.experiment.experimentmeta_pb2 import ExperimentConditional, ExperimentMeta
 
-from libsigopt.aux.errors import InvalidValueError, MissingJsonKeyError
+from libsigopt.aux.errors import InvalidKeyError, InvalidValueError, MissingJsonKeyError, MissingParamError
 
 
 class TestSetConditionalFromJson:
@@ -47,7 +46,7 @@ class TestSetConditionalFromJson:
     ],
   )
   def test_too_few_values_bad_param(self, conditional, conditional_json):
-    with pytest.raises(BadParamError):
+    with pytest.raises(MissingParamError):
       set_conditional_from_json(conditional, conditional_json)
 
 
@@ -76,7 +75,7 @@ class TestSetConditionalsListFromJson:
     assert len(experiment_meta.conditionals) == 0
 
   def test_duplicate_names(self, experiment_meta):
-    with pytest.raises(BadParamError):
+    with pytest.raises(InvalidKeyError):
       experiment_json = dict(
         conditionals=[
           dict(name="x", values=["10", "25"]),

--- a/test/python/sigopttest/handlers/validate/assignments_test.py
+++ b/test/python/sigopttest/handlers/validate/assignments_test.py
@@ -6,8 +6,9 @@ from mock import Mock
 
 from zigopt.experiment.model import Experiment
 from zigopt.handlers.validate.assignments import parameter_conditions_satisfied, validate_assignments_map
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.gen.experiment.experimentmeta_pb2 import ExperimentMeta, ParameterCondition
+
+from libsigopt.aux.errors import MissingParamError, SigoptValidationError
 
 
 class TestParameterConditionsSatisfied:
@@ -135,7 +136,7 @@ class TestValidateAssingmentsMap:
     ],
   )
   def test_missing_parameters(self, experiment, assignments):
-    with pytest.raises(BadParamError):
+    with pytest.raises(MissingParamError):
       validate_assignments_map(assignments, experiment)
 
   @pytest.mark.parametrize(
@@ -156,12 +157,12 @@ class TestValidateAssingmentsMap:
     ],
   )
   def test_missing_satisfied_parameters(self, experiment_with_conditionals, assignments):
-    with pytest.raises(BadParamError):
+    with pytest.raises(MissingParamError):
       validate_assignments_map(assignments, experiment_with_conditionals)
 
   @pytest.mark.parametrize("assignments", [dict(a=0, b=0), dict(a=0), dict(a=-1), dict()])
   def test_missing_conditionals(self, experiment_with_conditionals, assignments):
-    with pytest.raises(BadParamError):
+    with pytest.raises(MissingParamError):
       validate_assignments_map(assignments, experiment_with_conditionals)
 
 
@@ -211,5 +212,5 @@ class TestValidateAssignmentsMapConstraints:
     validate_assignments_map(assignments, experiment)
 
   def test_invalid_assignmnets(self, experiment, invalid_assignments):
-    with pytest.raises(BadParamError):
+    with pytest.raises(SigoptValidationError):
       validate_assignments_map(invalid_assignments, experiment)

--- a/test/python/sigopttest/parameters/from_json.py
+++ b/test/python/sigopttest/parameters/from_json.py
@@ -4,7 +4,6 @@
 import pytest
 from mock import Mock
 
-from zigopt.net.errors import BadParamError
 from zigopt.parameters.from_json import (
   set_categorical_values_from_json,
   set_parameter_conditions_from_json,
@@ -19,7 +18,13 @@ from zigopt.protobuf.gen.experiment.experimentmeta_pb2 import (
 )
 
 from libsigopt.aux.constant import ParameterPriorNames
-from libsigopt.aux.errors import InvalidKeyError, InvalidTypeError, InvalidValueError, MissingJsonKeyError
+from libsigopt.aux.errors import (
+  InvalidKeyError,
+  InvalidTypeError,
+  InvalidValueError,
+  MissingJsonKeyError,
+  SigoptValidationError,
+)
 
 
 class TestSetConditionsFromJson:
@@ -96,7 +101,7 @@ class TestSetConditionsFromJson:
     ],
   )
   def test_condition_name_with_no_value(self, parameter, invalid_parameter_json, conditionals_map):
-    with pytest.raises(BadParamError):
+    with pytest.raises(SigoptValidationError):
       set_parameter_conditions_from_json(parameter, invalid_parameter_json, conditionals_map)
 
   @pytest.mark.parametrize(
@@ -166,7 +171,7 @@ class TestSetCategoricalValuesFromJson:
     ],
   )
   def test_too_few_categorical_values(self, categorical_parameter, invalid_parameter_json):
-    with pytest.raises(BadParamError):
+    with pytest.raises(SigoptValidationError):
       set_categorical_values_from_json(categorical_parameter, invalid_parameter_json)
 
   @pytest.mark.parametrize(
@@ -241,7 +246,7 @@ class TestSetPriorFromJson:
     assert double_parameter.prior.normal_prior.scale == 1
 
     parameter_json = dict(prior=dict(name=ParameterPriorNames.NORMAL, mean=0, scale=-1))
-    with pytest.raises(BadParamError):
+    with pytest.raises(SigoptValidationError):
       set_prior_from_json(double_parameter, parameter_json)
 
   def test_set_beta_prior_from_json(self, double_parameter):
@@ -251,5 +256,5 @@ class TestSetPriorFromJson:
     assert double_parameter.prior.beta_prior.shape_b == 2
 
     parameter_json = dict(prior=dict(name=ParameterPriorNames.BETA, shape_a=0, shape_b=2))
-    with pytest.raises(BadParamError):
+    with pytest.raises(InvalidValueError):
       set_prior_from_json(double_parameter, parameter_json)

--- a/test/python/sigopttest/suggestion/from_json.py
+++ b/test/python/sigopttest/suggestion/from_json.py
@@ -4,7 +4,6 @@
 import pytest
 
 from zigopt.experiment.model import Experiment
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.gen.experiment.experimentmeta_pb2 import (
   PARAMETER_DOUBLE,
   Bounds,
@@ -14,7 +13,7 @@ from zigopt.protobuf.gen.experiment.experimentmeta_pb2 import (
 )
 from zigopt.suggestion.from_json import build_suggestion_data_from_json
 
-from libsigopt.aux.errors import InvalidTypeError
+from libsigopt.aux.errors import InvalidTypeError, SigoptValidationError
 
 
 class TestBuildSuggestionData:
@@ -53,7 +52,7 @@ class TestBuildSuggestionData:
       build_suggestion_data_from_json(experiment, json_dict)
 
     json_dict = {"assignments": {"x": 1.1, "what_is_this_parameter": 12345}}
-    with pytest.raises(BadParamError):
+    with pytest.raises(SigoptValidationError):
       build_suggestion_data_from_json(experiment, json_dict)
 
     json_dict = {"assignments": {"x": 1.1}, "task": {"name": "a"}}

--- a/test/python/sigopttest/task/from_json.py
+++ b/test/python/sigopttest/task/from_json.py
@@ -4,7 +4,6 @@
 import pytest
 
 from zigopt.experiment.model import Experiment
-from zigopt.net.errors import BadParamError
 from zigopt.protobuf.gen.experiment.experimentmeta_pb2 import (
   PARAMETER_DOUBLE,
   Bounds,
@@ -13,6 +12,8 @@ from zigopt.protobuf.gen.experiment.experimentmeta_pb2 import (
   Task,
 )
 from zigopt.task.from_json import extract_task_from_json
+
+from libsigopt.aux.errors import InvalidKeyError, SigoptValidationError
 
 
 class TestExtractors:
@@ -59,17 +60,17 @@ class TestExtractors:
     assert task.name == "a" and task.cost == 0.1
 
     json_dict = {"assignments": {"x": 1.1}, "wrong_tag": "a"}
-    with pytest.raises(BadParamError):
+    with pytest.raises(InvalidKeyError):
       extract_task_from_json(experiment_mt, json_dict)
 
     json_dict = {"assignments": {"x": 1.1}, "task": "not_a_real_task"}
-    with pytest.raises(BadParamError):
+    with pytest.raises(SigoptValidationError):
       extract_task_from_json(experiment_mt, json_dict)
 
     json_dict = {"assignments": {"x": 1.1}, "task": {"name": "not_a_real_task"}}
-    with pytest.raises(BadParamError):
+    with pytest.raises(SigoptValidationError):
       extract_task_from_json(experiment_mt, json_dict)
 
     json_dict = {"assignments": {"x": 1.1}, "task": {"forgot_the_name": "a"}}
-    with pytest.raises(BadParamError):
+    with pytest.raises(InvalidKeyError):
       extract_task_from_json(experiment_mt, json_dict)


### PR DESCRIPTION
Move a bunch (but not all) of our generic BadParamErrors to different, more descriptive, error types. 

Generally left some BadParamErrors if the error didn't feel like a `validation` error to me. 