### PR TITLE
no more scoped cookies, set cookies on self

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -34,7 +34,6 @@
   "web": {
     "cookiejar_force_path_style": true,
     "cookiejar_region": "us-eeast-1",
-    "scoped_cookie_name": "sigoptlocal-session-id",
     "static_asset_url": "https://sigopt.ninja:4443/static/a/",
     "static_routes": {
       "/static/a": {

--- a/config/development.json
+++ b/config/development.json
@@ -8,5 +8,8 @@
       "max_attempts": 10,
       "window_length": 600
     }
+  },
+  "web": {
+    "cookie_name": "sigoptdevelopment-session-id"
   }
 }

--- a/test/integration/web/cookie_test.py
+++ b/test/integration/web/cookie_test.py
@@ -16,8 +16,8 @@ class TestCookie(WebBase):
     return config_broker["web.cookiejar_bucket"]
 
   @pytest.fixture
-  def scoped_cookie_name(self, config_broker):
-    return config_broker.get("web.scoped_cookie_name", "sigopt-session-id")
+  def cookie_name(self, config_broker):
+    return config_broker.get("web.cookie_name", "sigopt-session-id")
 
   @pytest.fixture
   def s3_client(self, config_broker):
@@ -47,23 +47,21 @@ class TestCookie(WebBase):
       "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==",
     ],
   )
-  def test_invalid_session_id(self, scoped_cookie_name, web_connection, invalid_session_id):
-    response_cookies = web_connection.get("/", cookies={scoped_cookie_name: invalid_session_id}).response.cookies
-    new_session_id = response_cookies.get(scoped_cookie_name)
+  def test_invalid_session_id(self, cookie_name, web_connection, invalid_session_id):
+    response_cookies = web_connection.get("/", cookies={cookie_name: invalid_session_id}).response.cookies
+    new_session_id = response_cookies.get(cookie_name)
     assert new_session_id != invalid_session_id
     assert len(new_session_id) == 88
     assert new_session_id.endswith("..")
 
-  def test_corrupt_cookie_in_cookiejar(
-    self, s3_client, scoped_cookie_name, web_connection, cookiejar_bucket, config_broker
-  ):
+  def test_corrupt_cookie_in_cookiejar(self, s3_client, cookie_name, web_connection, cookiejar_bucket, config_broker):
     response = web_connection.get("/cookie").response
-    session_id = response.cookies.get(scoped_cookie_name)
+    session_id = response.cookies.get(cookie_name)
     assert json.load(s3_client.get_object(Bucket=cookiejar_bucket, Key=session_id)["Body"]) == response.json()
     s3_client.put_object(Bucket=cookiejar_bucket, Key=session_id, Body="invalid json")
     web_connection.get("/")
     response = web_connection.get("/cookie").response
-    session_id = response.cookies.get(scoped_cookie_name)
+    session_id = response.cookies.get(cookie_name)
     assert json.load(s3_client.get_object(Bucket=cookiejar_bucket, Key=session_id)["Body"]) == response.json()
 
   def check_cookie_was_deleted(self, s3_client, session_id, cookiejar_bucket):
@@ -71,19 +69,19 @@ class TestCookie(WebBase):
       s3_client.head_object(Bucket=cookiejar_bucket, Key=session_id)
     assert aws_error.value.response["Error"]["Code"] == "404"
 
-  def test_rotate_session_id_on_login(self, s3_client, scoped_cookie_name, web_connection, cookiejar_bucket):
+  def test_rotate_session_id_on_login(self, s3_client, cookie_name, web_connection, cookiejar_bucket):
     web_connection.get("/")
-    session_id = web_connection.cookies.get(scoped_cookie_name)
+    session_id = web_connection.cookies.get(cookie_name)
     web_connection.login()
-    assert web_connection.cookies.get(scoped_cookie_name) != session_id
+    assert web_connection.cookies.get(cookie_name) != session_id
     self.check_cookie_was_deleted(s3_client, session_id, cookiejar_bucket)
 
-  def test_rotate_session_id_on_logout(self, s3_client, scoped_cookie_name, logged_in_web_connection, cookiejar_bucket):
+  def test_rotate_session_id_on_logout(self, s3_client, cookie_name, logged_in_web_connection, cookiejar_bucket):
     web_connection = logged_in_web_connection
     csrf_token = web_connection.get("/cookie").response.json()["loginState"]["csrfToken"]
-    session_id = web_connection.cookies.get(scoped_cookie_name)
+    session_id = web_connection.cookies.get(cookie_name)
     web_connection.post(
       "/logout", data=f"csrf_token={csrf_token}", headers={"Content-Type": "application/x-www-form-urlencoded"}
     )
-    assert web_connection.cookies.get(scoped_cookie_name) != session_id
+    assert web_connection.cookies.get(cookie_name) != session_id
     self.check_cookie_was_deleted(s3_client, session_id, cookiejar_bucket)

--- a/test/integration/web/test_base.py
+++ b/test/integration/web/test_base.py
@@ -106,7 +106,7 @@ class WebConnection:
     browser_cookies = []
     for cookie_name, cookie_value in self.cookies.items():
       full_domain = domain
-      sigopt_cookie = config_broker.get("web.scoped_cookie_name", "sigopt-session-id")
+      sigopt_cookie = config_broker.get("web.cookie_name", "sigopt-session-id")
       is_local = "localhost" in domain or "127.0.0.1" in domain
       if not is_local and cookie_name == sigopt_cookie:
         full_domain = "." + domain


### PR DESCRIPTION
In order to better support changing the hostname that a client uses to access sigopt (ex. 127.0.0.1).