### PR TITLE
Typed remove_nones

### DIFF
--- a/src/python/zigopt/assignments/model.py
+++ b/src/python/zigopt/assignments/model.py
@@ -75,7 +75,7 @@ class HasAssignmentsMap(Proxy):
       # TODO(SN-1070): This calls make_experiment_assignment_value_array again redundantly, which
       # could be more efficient.
       assignments.update(self.get_conditional_assignments(experiment))
-    return remove_nones(assignments)
+    return remove_nones_mapping(assignments)
 
   def get_conditional_assignments(self, experiment):
     conditional_values = self._get_assignments_as_value_array(experiment.conditionals)

--- a/src/python/zigopt/authorization/guest.py
+++ b/src/python/zigopt/authorization/guest.py
@@ -83,7 +83,6 @@ class GuestAuthorization(EmptyAuthorization):
           napply(experiment, lambda e: e.project_id),
           napply(training_run, lambda t: t.project_id),
         ],
-        list,
       )
     )
     if len(project_ids) != 1:

--- a/src/python/zigopt/common/lists.py
+++ b/src/python/zigopt/common/lists.py
@@ -19,7 +19,6 @@ from typing import Mapping as _Mapping
 from typing import Optional as _Optional
 from typing import ParamSpec as _ParamSpec
 from typing import Sequence as _Sequence
-from typing import Set as _Set
 from typing import TypeVar as _TypeVar
 
 import numpy as _numpy
@@ -135,31 +134,11 @@ def remove_nones_mapping(dct: _Mapping[lists_GHashable, _Optional[lists_T]]) -> 
   return {k: v for k, v in dct.items() if v is not None}
 
 
-def remove_nones_set(lis: _Set[_Optional[lists_T]]) -> _Set[lists_T]:
-  return {v for v in lis if v is not None}
-
-
 def remove_nones_sequence(
-  lis: _Sequence[_Optional[lists_T]], cls: type[list] | type[tuple]
+  lis: _Sequence[_Optional[lists_T]],
+  cls: type[list] | type[tuple] = list,
 ) -> list[lists_T] | tuple[lists_T, ...]:
   return cls(l for l in lis if l is not None)
-
-
-def remove_nones(
-  lis: _Sequence[_Optional[lists_T]] | _Mapping[lists_GHashable, _Optional[lists_T]] | _Set[_Optional[lists_T]]
-) -> _Sequence[lists_T] | _Mapping[lists_GHashable, lists_T] | _Set[lists_T]:
-  """
-    Returns a copy of this object with all `None` values removed.
-    """
-  if is_mapping(lis):
-    assert isinstance(lis, _collectionsabc.Mapping)
-    return remove_nones_mapping(lis)
-  if is_set(lis):
-    assert isinstance(lis, _collectionsabc.Set)
-    return remove_nones_set(lis)
-  if isinstance(lis, list | tuple):
-    return remove_nones_sequence(lis, type(lis))
-  raise ValueError(f"Invalid type for remove_nones: {type(lis)}")
 
 
 def coalesce(*args: _Any) -> _Any:

--- a/src/python/zigopt/common/lists.py
+++ b/src/python/zigopt/common/lists.py
@@ -136,16 +136,15 @@ def remove_nones_mapping(dct: _Mapping[lists_GHashable, _Optional[lists_T]]) -> 
 
 def remove_nones_sequence(
   lis: _Sequence[_Optional[lists_T]],
-  cls: type[list] | type[tuple] = list,
 ) -> list[lists_T] | tuple[lists_T, ...]:
-  return cls(l for l in lis if l is not None)
+  return [l for l in lis if l is not None]
 
 
 def coalesce(*args: _Any) -> _Any:
   """
     Returns the first non-None value, or None if no such value exists
     """
-  return list_get(remove_nones_sequence(args, tuple), 0)
+  return list_get(remove_nones_sequence(args), 0)
 
 
 def map_dict(func: _Callable[[lists_T], lists_R], d: dict[lists_GHashable, lists_T]) -> dict[lists_GHashable, lists_R]:

--- a/src/python/zigopt/db/service.py
+++ b/src/python/zigopt/db/service.py
@@ -290,7 +290,7 @@ class DatabaseService(Service):
   def upsert(self, obj, where=None, skip_none=False):
     column_values = self._get_column_values(obj)
     if skip_none:
-      column_values = remove_nones(column_values)
+      column_values = remove_nones_sequence(column_values)
     self.execute(
       postgresql_insert(obj.__table__)
       .values(**column_values)

--- a/src/python/zigopt/exception/logger.py
+++ b/src/python/zigopt/exception/logger.py
@@ -75,7 +75,7 @@ class ExceptionLogger(Service):
   def _update_extra(self, extra):
     extra = extend_dict({}, self._extra, extra or {})
     extra.update(
-      remove_nones(
+      remove_nones_mapping(
         {
           "request_id": self.services.logging_service.request_id,
           "trace_id": self.services.logging_service.trace_id,

--- a/src/python/zigopt/experiment/best.py
+++ b/src/python/zigopt/experiment/best.py
@@ -1,7 +1,7 @@
 # Copyright © 2022 Intel Corporation
 #
 # SPDX-License-Identifier: Apache License 2.0
-from zigopt.common import is_number, max_option, remove_nones
+from zigopt.common import is_number, max_option, remove_nones_sequence
 from zigopt.experiment.util import get_experiment_default_metric_name
 from zigopt.services.base import Service
 
@@ -84,5 +84,5 @@ class ExperimentBestObservationService(Service):
       best_observations = self.multiple_solutions_best(experiment, observations)
     else:
       best_observation = self.single_metric_best(experiment, observations, cost=1)
-      best_observations = remove_nones([best_observation])
+      best_observations = remove_nones_sequence([best_observation])
     return best_observations

--- a/src/python/zigopt/handlers/clients/update.py
+++ b/src/python/zigopt/handlers/clients/update.py
@@ -54,7 +54,7 @@ class ClientsUpdateHandler(ClientHandler):
     self.services.iam_logging_service.log_iam(
       requestor=self.auth.current_user,
       event_name=IamEvent.CLIENT_UPDATE,
-      request_parameters=remove_nones(
+      request_parameters=remove_nones_mapping(
         {
           "name": name,
           "client_security": client_security,

--- a/src/python/zigopt/handlers/experiments/update.py
+++ b/src/python/zigopt/handlers/experiments/update.py
@@ -264,7 +264,7 @@ class ExperimentsUpdateHandler(ExperimentHandler):
     if not parameters_json:
       raise SigoptValidationError("Experiments must have at least one parameter.")
 
-    name_counts: dict[str, int] = distinct_counts(remove_nones_sequence([p.get("name") for p in parameters_json], list))
+    name_counts: dict[str, int] = distinct_counts(remove_nones_sequence([p.get("name") for p in parameters_json]))
     duplicates = [key for (key, value) in name_counts.items() if value > 1]
     if len(duplicates) > 0:
       raise InvalidValueError(f"Duplicate parameter names: {duplicates}")

--- a/src/python/zigopt/handlers/organizations/clients.py
+++ b/src/python/zigopt/handlers/organizations/clients.py
@@ -29,7 +29,7 @@ class OrganizationsClientsListDetailHandler(OrganizationHandler):
     )
     clients = self.services.client_service.find_clients_in_organizations_visible_to_user(
       user=self.auth.current_user,
-      memberships=remove_nones([membership]),
+      memberships=remove_nones_sequence([membership]),
     )
 
     return PaginationJsonBuilder(data=[ClientJsonBuilder(c) for c in clients])

--- a/src/python/zigopt/handlers/users/update.py
+++ b/src/python/zigopt/handlers/users/update.py
@@ -68,7 +68,7 @@ class UsersUpdateHandler(UserHandler):
     self.services.iam_logging_service.log_iam(
       requestor=self.auth.current_user,
       event_name=IamEvent.USER_UPDATE,
-      request_parameters=remove_nones(
+      request_parameters=remove_nones_mapping(
         {
           "user_id": self.user.id,
           "name": uploaded_user.name,

--- a/src/python/zigopt/handlers/validate/metadata.py
+++ b/src/python/zigopt/handlers/validate/metadata.py
@@ -35,7 +35,7 @@ def _schema_validate(metadata: dict[str, Any], length: int, key_length: int, max
 
 def validate_custom_json(metadata: dict[str, Any]) -> Optional[str]:
   if metadata is not None:
-    return json.dumps(remove_nones(metadata))
+    return json.dumps(remove_nones_mapping(metadata))
   return None
 
 

--- a/src/python/zigopt/optimize/queue.py
+++ b/src/python/zigopt/optimize/queue.py
@@ -29,7 +29,6 @@ class OptimizeQueueService(Service):
           ),
           *self._maybe_enqueue_importances(experiment, num_observations, force=force),
         ],
-        list,
       )
       self.services.queue_monitor.robust_enqueue(messages, experiment)
 

--- a/src/python/zigopt/optimize/worker.py
+++ b/src/python/zigopt/optimize/worker.py
@@ -47,7 +47,7 @@ class ExperimentWorker(QueueWorker):
         timing_info["time_avail"] = start_time - self.enqueue_time
       logger.info(
         json.dumps(
-          remove_nones(
+          remove_nones_mapping(
             dict(
               state="processing",
               **logging_info,
@@ -83,7 +83,7 @@ class ExperimentWorker(QueueWorker):
       logger.info("Finished processing for experiment %s", experiment.id)
       logger.info(
         json.dumps(
-          remove_nones(
+          remove_nones_mapping(
             dict(
               state="finished",
               **logging_info,
@@ -99,7 +99,7 @@ class ExperimentWorker(QueueWorker):
       logger.warning("Skipping unneeded processing for experiment %s", experiment_id)
       logger.warning(
         json.dumps(
-          remove_nones(
+          remove_nones_mapping(
             dict(
               state="skipped",
               **logging_info,

--- a/src/python/zigopt/profile/timing.py
+++ b/src/python/zigopt/profile/timing.py
@@ -22,7 +22,7 @@ def time_function(logger_name, log_attributes=lambda *args, **kwargs: None):
         services = getattr(f_self, "services", None)
         logger.debug(
           json.dumps(
-            remove_nones(
+            remove_nones_mapping(
               dict(
                 className=type(f_self).__name__,
                 functionName=f.__name__,

--- a/src/python/zigopt/queue/monitor.py
+++ b/src/python/zigopt/queue/monitor.py
@@ -88,7 +88,7 @@ class QueueMonitor(Service):
     return self.services.redis_key_service.create_queue_name_key("queue-monitor", queue_name, ":")
 
   def _get_status(self, queue_name):
-    return remove_nones(
+    return remove_nones_mapping(
       {
         key.decode(): napply(value, float)
         for key, value in self.services.redis_service.get_all_hash_fields(self._queue_monitor_name(queue_name)).items()
@@ -97,7 +97,7 @@ class QueueMonitor(Service):
 
   def _update_status(self, queue_name, status):
     with self.services.exception_logger.tolerate_exceptions(RedisServiceError):
-      status = remove_nones(status)
+      status = remove_nones_mapping(status)
       if status:
         self.services.redis_service.set_hash_fields(self._queue_monitor_name(queue_name), status)
 

--- a/src/python/zigopt/queue/monitor.py
+++ b/src/python/zigopt/queue/monitor.py
@@ -118,7 +118,6 @@ class QueueMonitor(Service):
             queue_status.get(LAST_DEQUEUE),
             queue_status.get(LAST_EMPTY),
           ),
-          list,
         )
       )
       last_enqueue = queue_status.get(LAST_ENQUEUE)

--- a/src/python/zigopt/token/service.py
+++ b/src/python/zigopt/token/service.py
@@ -14,7 +14,7 @@ from zigopt.token.token_types import TokenType
 
 class TokenService(Service):
   def _reject_expired(self, tokens: Sequence[Token]):
-    expired, valid = partition(remove_nones_sequence(tokens, list), lambda t: t.expired)
+    expired, valid = partition(remove_nones_sequence(tokens), lambda t: t.expired)
     if expired:
       self.delete_tokens(expired)
     return valid
@@ -68,7 +68,7 @@ class TokenService(Service):
     # pylint: disable=protobuf-undefined-attribute
     meta.SetFieldIfNotNone(  # type: ignore
       "ttl_seconds",
-      min_option(remove_nones_sequence(ttl_options, list)),
+      min_option(remove_nones_sequence(ttl_options)),
     )
     # pylint: enable=protobuf-undefined-attribute
     return meta

--- a/src/python/zigopt/training_run/defined_fields.py
+++ b/src/python/zigopt/training_run/defined_fields.py
@@ -119,7 +119,7 @@ class TrainingRunDefinedFieldsExtractor:
         api_type = field_details.api_type
         name = field_details.readable_name
 
-      key = ".".join(remove_nones(field_keys))
+      key = ".".join(remove_nones_sequence(field_keys))
       yield DefinedField(
         api_type=api_type,
         field_count=count,

--- a/src/python/zigopt/utils/create_database.py
+++ b/src/python/zigopt/utils/create_database.py
@@ -99,7 +99,7 @@ def setup_db(config_broker, allow_list=True, superuser=None, superuser_password=
     "port": config_broker.get("db.port"),
     **(config_broker.get("db.query") or {}),
   }
-  conn = pg8000.connect(**remove_nones(args))
+  conn = pg8000.connect(**remove_nones_mapping(args))
   try:
     conn.autocommit = True
     with conn.cursor() as cursor:

--- a/src/python/zigopt/utils/create_produser.py
+++ b/src/python/zigopt/utils/create_produser.py
@@ -24,7 +24,7 @@ def make_db_connection(host, port, database, query, user, password):
     "password": password,
     **(query or {}),
   }
-  conn = pg8000.connect(**remove_nones(options))
+  conn = pg8000.connect(**remove_nones_mapping(options))
   try:
     conn.autocommit = True
     yield conn

--- a/test/integration/v1/endpoints/aiexperiments/list_test.py
+++ b/test/integration/v1/endpoints/aiexperiments/list_test.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 import pytest
 
-from zigopt.common import remove_nones
+from zigopt.common import remove_nones_mapping
 from zigopt.common.sigopt_datetime import current_datetime
 from zigopt.common.strings import random_string
 from zigopt.experiment.model import Experiment
@@ -101,7 +101,7 @@ class TestListAiExperiments(ExperimentsTestBase):
       connection.as_client_only().aiexperiments().fetch,
       connection.clients(project1.client_id).projects(project1.reference_id).aiexperiments().fetch,
     ):
-      paging = func(**remove_nones(params))
+      paging = func(**remove_nones_mapping(params))
       assert paging.count == 2
       if ascending:
         assert paging.paging.after is None
@@ -136,7 +136,7 @@ class TestListAiExperiments(ExperimentsTestBase):
       connection.as_client_only().aiexperiments().fetch,
       connection.clients(project1.client_id).projects(project1.reference_id).aiexperiments().fetch,
     ):
-      page = func(**remove_nones(params))
+      page = func(**remove_nones_mapping(params))
       assert page.count == 2
       assert len(page.data) == 1
       ids = [page.data[0].id]
@@ -145,7 +145,7 @@ class TestListAiExperiments(ExperimentsTestBase):
         next_page_params["after"] = page.paging.after
       else:
         next_page_params["before"] = page.paging.before
-      page = func(**remove_nones(next_page_params))
+      page = func(**remove_nones_mapping(next_page_params))
       assert page.count == 2
       assert len(page.data) == 1
       if ascending:

--- a/test/python/sigopttest/common/lists.py
+++ b/test/python/sigopttest/common/lists.py
@@ -90,52 +90,56 @@ class TestLists:
     with pytest.raises(ValueError):
       compact(numpy.array([]))  # type: ignore
 
-  def test_remove_nones(self):
-    assert remove_nones(()) == ()
-    assert remove_nones((False, None, [], 0, {})) == (False, [], 0, {})
-    assert remove_nones((False, None, [], 0, {}, 1, 2, 3, True, [1])) == (False, [], 0, {}, 1, 2, 3, True, [1])
+  @pytest.mark.parametrize(
+    "input_data,expected",
+    [
+      ((), []),
+      ((False, None, [], 0, {}), [False, [], 0, {}]),
+      ((False, None, [], 0, {}, 1, 2, 3, True, [1]), [False, [], 0, {}, 1, 2, 3, True, [1]]),
+      ([], []),
+      ([False, None, [], 0, {}], [False, [], 0, {}]),
+      ([False, None, [], 0, {}, 1, 2, 3, True, [1]], [False, [], 0, {}, 1, 2, 3, True, [1]]),
+    ],
+  )
+  def test_remove_nones_sequence(self, input_data, expected):
+    assert remove_nones_sequence(input_data) == expected
 
-    assert remove_nones([]) == []
-    assert remove_nones([False, None, [], 0, {}]) == [False, [], 0, {}]
-    assert remove_nones([False, None, [], 0, {}, 1, 2, 3, True, [1]]) == [False, [], 0, {}, 1, 2, 3, True, [1]]
-    assert remove_nones({}) == {}
-    assert remove_nones({"a": False, "b": None, "c": [], "d": 0, "e": {}}) == {
-      "a": False,
-      "c": [],
-      "d": 0,
-      "e": {},
-    }
-    assert remove_nones({"a": False, "b": None, "c": [], "d": 0, "e": {}, "f": 1, "g": True}) == {
-      "a": False,
-      "c": [],
-      "d": 0,
-      "e": {},
-      "f": 1,
-      "g": True,
-    }
-    assert remove_nones({"a": {"b": None}}) == {
-      "a": {
-        "b": None,
-      },
-    }
-    assert remove_nones(set((1, "a", None))) == set((1, "a"))
-    assert remove_nones(set((1, "a"))) == set((1, "a"))
-    assert remove_nones(set()) == set()
-
-    with pytest.raises(ValueError):
-      remove_nones(None)  # type: ignore
-
-    with pytest.raises(ValueError):
-      remove_nones(1)  # type: ignore
-
-    with pytest.raises(ValueError):
-      remove_nones("abc")  # type: ignore
-
-    with pytest.raises(ValueError):
-      remove_nones(b"abc")  # type: ignore
-
-    with pytest.raises(ValueError):
-      remove_nones(numpy.array([]))  # type: ignore
+  @pytest.mark.parametrize(
+    "input_data,expected",
+    [
+      ({}, {}),
+      (
+        {"a": False, "b": None, "c": [], "d": 0, "e": {}},
+        {
+          "a": False,
+          "c": [],
+          "d": 0,
+          "e": {},
+        },
+      ),
+      (
+        {"a": False, "b": None, "c": [], "d": 0, "e": {}, "f": 1, "g": True},
+        {
+          "a": False,
+          "c": [],
+          "d": 0,
+          "e": {},
+          "f": 1,
+          "g": True,
+        },
+      ),
+      (
+        {"a": {"b": None}},
+        {
+          "a": {
+            "b": None,
+          },
+        },
+      ),
+    ],
+  )
+  def test_remove_nones_mapping(self, input_data, expected):
+    assert remove_nones_mapping(input_data) == expected
 
   def test_coalesce(self):
     assert coalesce() is None

--- a/test/python/sigopttest/log/base.py
+++ b/test/python/sigopttest/log/base.py
@@ -10,7 +10,7 @@ import pytest
 from freezegun import freeze_time
 from mock import Mock
 
-from zigopt.common import remove_nones
+from zigopt.common import remove_nones_mapping
 from zigopt.log.base import JsonFormatter, SyslogFormatter
 
 
@@ -132,7 +132,7 @@ class TestSyslogFormatter:
 
   @freeze_time("2018-01-01", tz_offset=0)
   def test_format(self, record):
-    assert remove_nones(self.as_json(SyslogFormatter().format(record))) == {
+    assert remove_nones_mapping(self.as_json(SyslogFormatter().format(record))) == {
       "environment": "unknown",
       "level": "WARNING",
       "loggerName": "sigopt.log",


### PR DESCRIPTION
Having a single function that handles all these cases hides typing information (by returning a number of different output types) and hides dead code (ex. `remove_nones_set` was only used by the tests).