### PR TITLE
remove yarn audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,9 +30,3 @@ jobs:
         with:
           name: trivy-images-results
           path: artifacts/trivy/
-  yarn-audit:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-      - run: yarn audit


### PR DESCRIPTION
This was meant as a back-up in case Trivy scans silently failed, but Trivy is now doing it's job without issues.