### PR TITLE
Better rewriting and proxy_pass directive

### DIFF
--- a/nginx/proxy/api.conf
+++ b/nginx/proxy/api.conf
@@ -27,7 +27,7 @@ location /api/ {
 
   rewrite ^/api(.*) $1 break;
 
-  proxy_pass http://$backend$uri$is_args$args;
+  proxy_pass http://$backend;
   proxy_redirect ~^(.*)$ /api$1;
 }
 

--- a/nginx/proxy/api.conf
+++ b/nginx/proxy/api.conf
@@ -25,10 +25,9 @@ location /api/ {
     return 405;
   }
 
-  rewrite ^ $request_uri;
   rewrite ^/api(.*) $1 break;
 
-  proxy_pass http://$backend$uri;
+  proxy_pass http://$backend$uri$is_args$args;
   proxy_redirect ~^(.*)$ /api$1;
 }
 

--- a/nginx/proxy/webpack.conf
+++ b/nginx/proxy/webpack.conf
@@ -2,7 +2,7 @@ location /webpack/ {
   set $backend webpack.ninja:7800;
   rewrite ^ $request_uri;
   rewrite ^/webpack(.*) $1 break;
-  proxy_pass https://$backend$uri;
+  proxy_pass https://$backend$uri$is_args$args;
   proxy_redirect off;
   proxy_http_version 1.1;
   proxy_set_header Access-Control-Allow-Origin "*";

--- a/nginx/proxy/webpack.conf
+++ b/nginx/proxy/webpack.conf
@@ -1,6 +1,5 @@
 location /webpack/ {
   set $backend webpack.ninja:7800;
-  rewrite ^ $request_uri;
   rewrite ^/webpack(.*) $1 break;
   proxy_pass https://$backend$uri$is_args$args;
   proxy_redirect off;

--- a/nginx/proxy/webpack.conf
+++ b/nginx/proxy/webpack.conf
@@ -1,7 +1,7 @@
 location /webpack/ {
   set $backend webpack.ninja:7800;
   rewrite ^/webpack(.*) $1 break;
-  proxy_pass https://$backend$uri$is_args$args;
+  proxy_pass https://$backend;
   proxy_redirect off;
   proxy_http_version 1.1;
   proxy_set_header Access-Control-Allow-Origin "*";


### PR DESCRIPTION
After reading the docs I think the original solution was not great. This new solution strips the prefix from the normalized `$uri` variable, then passes on the parsed query string parameters explicitly. I think header injection is not possible because we are passing on the `$uri` variable and parsed `$args`, not the raw `$request_uri`