### PR TITLE
Switch to team based alerting

### DIFF
--- a/.github/auto_assign-issues.yml
+++ b/.github/auto_assign-issues.yml
@@ -1,3 +1,2 @@
 assignees:
-  - Chris-Sigopt
-  - tjs-intel
+  - sigopt/Dev

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # default fallback for all files:
-* @Chris-Sigopt @tjs-intel
+* @sigopt/Dev


### PR DESCRIPTION
Use teams to centrally manage approvers/maintainers. 