### PR TITLE
Ignore CVE

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -6,3 +6,4 @@ CVE-2024-26462 # 2024-02-29 :: trivy-scan-zigopt :: libgssapi-krb5-2, libk5crypt
 CVE-2023-50387 # 2024-02-29 :: trivy-scan-zigopt :: libsystemd0, libudev1 :: no-fix-yet
 CVE-2023-50868 # 2024-02-29 :: trivy-scan-zigopt :: libsystemd0, libudev1 :: no-fix-yet
 CVE-2024-33599 # 2024-04-29 :: trivy-scan-zigopt :: libc-bin, libc6 :: no-fix-yet
+CVE-2024-6484  # 2024-08-19 :: trivy-scan-aux    :: bootstrap :: no-fix-yet on version


### PR DESCRIPTION
This error is in a component we don't use, and the LOE to upgrade to Bootstrap 5 seems too much. 